### PR TITLE
Adding support for Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This tutorial introduces main features of PyDevice through examples.
 
 ### Sample Python code
 
-Let's start with defining a standalone Python class that provides an interface to our device, in a file called mydevice.py: 
+Let's start with defining a standalone Python class that provides an interface to our device, in a file called mydevice.py:
 
 ``` python
 import socket
@@ -268,17 +268,19 @@ Single thread policy doesn't apply to any threads spawned from Python code.
 * EPICS 3.14+ or 7.0+
 * Python 2.x or 3.5+ headers and libraries
     * RHEL: yum install python-devel
-    * Debian & Ubuntu: apt install python-dev
-    
+    * Debian & Ubuntu:
+       * For python2: apt install python-dev
+       * For python3: apt install python3-dev
+
 ### Compiling PyDevice
 
-In order to PyDevice, all its dependencies must be installed. In configure/RELEASE file change EPICS_BASE. Afterwards issue *make* command in the top level. The compilation will provide dynamic library to be included in the IOC as well as a testing IOC that can be executed from iocBoot/iocpydev folder.
+In order to PyDevice, all its dependencies must be installed. In configure/RELEASE file change EPICS_BASE. In configure/CONFIG_SITE set PYTHON_CONFIG=python3-config if you want to use python3. Set Afterwards issue *make* command in the top level. The compilation will provide dynamic library to be included in the IOC as well as a testing IOC that can be executed from iocBoot/iocpydev folder.
 
 Assuming all dependencies are satisfied, project should build linkable library and testing IOC binary. Running st.cmd from test iocBoot/iocpydev folder will start the demo IOC. At this point database and Python code can be modified without rebuilding the PyDevice source code.
 
 ### Adding PyDevice support to IOC
 
-For the existing IOC to receive PyDevice support, a few things need to be added. 
+For the existing IOC to receive PyDevice support, a few things need to be added.
 
 * Edit configure/RELEASE and add PYDEVICE variable to point to PyDevice source location
 * Edit Makefile in IOC's App/src folder and add

--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -19,6 +19,10 @@ include $(CONFIG)/CONFIG
 # Override the Base definition:
 INSTALL_LOCATION = $(TOP)
 
+# As soon as python3 is the default configuration
+# PYTHON_CONFIG=python3-config
+PYTHON_CONFIG=python-config
+
 # CONFIG_SITE files contain other build configuration settings
 include $(TOP)/configure/CONFIG_SITE
 -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
@@ -26,4 +30,3 @@ ifdef T_A
  -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
  -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
 endif
-

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -1,5 +1,7 @@
 # CONFIG_SITE
 
+# PYTHON_CONFIG=python3-config
+
 # Make any application-specific changes to the EPICS build
 #   configuration variables in this file.
 #

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -1,5 +1,7 @@
 # CONFIG_SITE
 
+# Set this if you intend to build with a specific python version
+#   e.g. using python3
 # PYTHON_CONFIG=python3-config
 
 # Make any application-specific changes to the EPICS build

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,8 +4,8 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 
-USR_LDFLAGS += $(shell python-config --ldflags)
-USR_CXXFLAGS += $(subst -Wstrict-prototypes,,$(shell python-config --cflags))
+USR_LDFLAGS += $(shell $(PYTHON_CONFIG) --ldflags)
+USR_CXXFLAGS += $(subst -Wstrict-prototypes,,$(shell $(PYTHON_CONFIG) --cflags))
 USR_CXXFLAGS += -std=c++11
 #CXXFLAGS += -g -ggdb -O0
 

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -111,7 +111,6 @@ bool PyWrapper::init()
     // communication channel for I/O Intr value exchange
     PyImport_AppendInittab("pydev", &PyInit_pydev);
 
-    // Py_SetProgramName(L"python3.7");
     Py_Initialize();
     PyEval_InitThreads();
 
@@ -342,7 +341,6 @@ void PyWrapper::exec(const std::string& line, bool debug)
     PyObject* r = PyRun_String(line.c_str(), Py_file_input, globDict, locDict);
     if (r == nullptr) {
         if (debug && PyErr_Occurred()) {
-            std::cerr << "Tried to execute string '" << line << "'" << std::endl;
             PyErr_Print();
         }
         PyErr_Clear();
@@ -377,7 +375,6 @@ bool PyWrapper::exec(const std::string& line, bool debug, T* val)
     PyObject* r = PyRun_String(line.c_str(), Py_single_input, globDict, locDict);
     if (r == nullptr) {
         if (PyErr_Occurred()) {
-            std::cerr << "Tried to execute string '" << line << "'" << std::endl;
             PyErr_Print();
         }
         PyErr_Clear();

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -6,7 +6,7 @@
 #include "pywrapper.h"
 
 #include <Python.h>
- 
+
 #include <map>
 #include <stdexcept>
 #include <iostream>
@@ -46,11 +46,20 @@ static PyObject* pydev_iointr(PyObject* self, PyObject* args)
     std::string name = PyString_AsString(param);
 #else /* PY_MAJOR_VERSION < 3 */
     PyObject* tmp = nullptr;
-    if (!PyUnicode_Check(param) || ((tmp=PyUnicode_AsASCIIString(param)) == nullptr)) {
-        PyErr_SetString(PyExc_TypeError, "Parameter name is not a string");
+    if (!PyUnicode_Check(param)){
+        PyErr_SetString(PyExc_TypeError, "Parameter name is not a unicode");
         Py_RETURN_NONE;
     }
-    std::string name = PyByteArray_AsString(tmp);
+    tmp = PyUnicode_AsASCIIString(param);
+    if(!tmp){
+        PyErr_SetString(PyExc_TypeError, "Unicode could not be converted to ASCII");
+        Py_RETURN_NONE;
+    }
+    if(!PyBytes_Check(tmp)){
+        PyErr_SetString(PyExc_TypeError, "PyUnicode as ASCII did not return expected bytes object!");
+        Py_RETURN_NONE;
+    }
+    std::string name = PyBytes_AsString(tmp);
     Py_XDECREF(tmp);
 #endif /* PY_MAJOR_VERSION < 3 */
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4,7 +4,7 @@
 \*************************************************************************/
 
 #include "util.h"
-
+#include <stdexcept>
 namespace Util {
 
 std::map<std::string, std::string> getReplacables(const std::string& text)

--- a/testApp/src/Makefile
+++ b/testApp/src/Makefile
@@ -35,7 +35,7 @@ pydevioc_SRCS_vxWorks += -nil-
 
 # Finally link to the EPICS Base libraries
 pydevioc_LIBS += $(EPICS_BASE_IOC_LIBS)
-SYS_PROD_LIBS += $(shell python-config --ldflags | sed 's/-[^l][^ ]*//g' | sed 's/-l//g')
+SYS_PROD_LIBS += $(shell $(PYTHON_CONFIG) --ldflags | sed 's/-[^l][^ ]*//g' | sed 's/-l//g')
 
 #===========================
 


### PR DESCRIPTION
Summary
----------

The codebase was prepared for python 3 but not finished (e.g. module initatlisation). Some bits and pieces were added. 
Now PyDevice can be compiled with python3. First tests indicate that it should work.

Changes
---------

* A onfiguration variable was added for python-config named PYTHON_CONFIG. This allows selecting which
  python-config to be used. Thus the code can be compiled against python2 or python3. The user would set
  PYTHON_CONFIG=python-config for python2 and PYTHON_CONFIG=python3-config for python3 on a 
  current debian system.
* Pywrapper support for python3 was pushed forward:
  
     * The module dictionary of `__main__` is now used as global dictonary. In this manner the functionality
        of __import__ is not lost.
     * A preprocessor variable `PYDEV_PYCAPI_COMPAT_VERSION2` is used to select the code parts that are
       required for python2 or python3. 
     * Some checks were added that would emmit a warning if ome obscure python version would be used.




