### PR TITLE
Build fixes for Debian Bullseye with Base 3.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ define DIR_template
 endef
 $(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir))))
 
+testApp_DEPEND_DIRS += src
 iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 
 include $(TOP)/configure/RULES_TOP

--- a/src/asyncexec.cpp
+++ b/src/asyncexec.cpp
@@ -10,9 +10,11 @@
 #include <epicsThread.h>
 
 #include <atomic>
+#include <cstdio>
 #include <list>
 #include <memory>
 #include <vector>
+#include <string>
 
 template<typename T>
 class TaskQueue {


### PR DESCRIPTION
When trying to build on Debian Bullseye with base 3.15, I had to add these missing includes.
Also parallel builds were unreliable without the additional depends definition.

Sorry, I accidentaly submitted and closed this PR before putting anyhting here. Hope my editing work.