### PR TITLE
Don't set val from rval after record initialization for ao, bo and mbbo

### DIFF
--- a/src/pydev_ao.cpp
+++ b/src/pydev_ao.cpp
@@ -65,7 +65,7 @@ static long initRecord(aoRecord* rec)
         ctx->scan = nullptr;
     }
 
-    return 0;
+    return 2;
 }
 
 static long getIointInfo(int /*direction*/, aoRecord *rec, IOSCANPVT* io)

--- a/src/pydev_bo.cpp
+++ b/src/pydev_bo.cpp
@@ -65,7 +65,7 @@ static long initRecord(boRecord* rec)
         ctx->scan = nullptr;
     }
 
-    return 0;
+    return 2;
 }
 
 static long getIointInfo(int /*direction*/, boRecord *rec, IOSCANPVT* io)

--- a/src/pydev_mbbo.cpp
+++ b/src/pydev_mbbo.cpp
@@ -65,7 +65,7 @@ static long initRecord(mbboRecord* rec)
         ctx->scan = nullptr;
     }
 
-    return 0;
+    return 2;
 }
 
 static long getIointInfo(int /*direction*/, mbboRecord *rec, IOSCANPVT* io)


### PR DESCRIPTION
Record initialization for ao, bo and mbbo returns 0. This requests conversion, i.e., setting VAL from RVAL using AOFF, EOFF etc. This means you can't set VAL in the db-file, it gets overridden in record intialization.
Returning 0 could make sense if one were to set RVAL in the record initialization routine, e.g., because it was read from the device. However, I think there is little use for it in pydevice, particularly because RVAL must be an integer.
Therefor, I suggest returning 2, indicating success, but no conversion.