### PR TITLE
add mutex to prevent callback and scheduling of callback from running at the same time                      

### DIFF
--- a/src/asyncexec.cpp
+++ b/src/asyncexec.cpp
@@ -16,6 +16,8 @@
 #include <vector>
 #include <string>
 
+epicsMutex mutex2;
+
 template<typename T>
 class TaskQueue {
     private:
@@ -74,7 +76,9 @@ class WorkerThread : public epicsThreadRunable {
             while (running) {
                 AsyncExec::Callback cb;
                 if (g_tasks.dequeue(1.0, cb)) {
+                    mutex2.lock();
                     cb();
+                    mutex2.unlock();
                 }
             }
         }
@@ -114,8 +118,10 @@ void AsyncExec::shutdown()
 
 bool AsyncExec::schedule(const AsyncExec::Callback& callback)
 {
+    mutex2.lock();
     if (g_workers.empty() || !callback)
         return false;
     g_tasks.enqueue(callback);
+    mutex2.unlock();
     return true;
 }


### PR DESCRIPTION
This is to fix an apparent bug where pydev.iointr sometimes randomly sets the record value to 0 instead of the commanded value.

Here is a camonitor of some records whose value (for testing purposes) I was forcing to 5 via "pydev.iointr('interrupt_name', 5)":


```
BL100:DH1:FitPeak1:mu          <undefined> 0 UDF INVALID
BL100:DH1:FitPeak1:sigma       <undefined> 0 UDF INVALID
BL100:DH1:FitPeak1:mu          2023-08-14 17:43:28.540899 5  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:43:28.540962 5  
BL100:DH1:FitPeak1:mu          2023-08-14 17:43:48.937786 0  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:43:48.937853 0  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:43:53.866330 5  
BL100:DH1:FitPeak1:mu          2023-08-14 17:43:53.866379 5  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:44:49.731883 0  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:44:54.812919 5  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:45:35.569960 0  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:45:40.684354 5  
BL100:DH1:FitPeak1:mu          2023-08-14 17:45:50.661259 0  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:45:50.661336 0  
BL100:DH1:FitPeak1:mu          2023-08-14 17:45:55.894239 5  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:46:00.928380 5  
BL100:DH1:FitPeak1:mu          2023-08-14 17:46:11.022913 0  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:46:11.022986 0  
BL100:DH1:FitPeak1:mu          2023-08-14 17:46:16.110062 5  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:46:21.236704 5  
BL100:DH1:FitPeak1:mu          2023-08-14 17:46:36.530298 0  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:46:36.530371 0  
BL100:DH1:FitPeak1:mu          2023-08-14 17:46:41.669093 5  
BL100:DH1:FitPeak1:sigma       2023-08-14 17:46:41.672415 5  
BL100:DH1:FitPeak1:mu          2023-08-14 17:46:46.643396 0  
BL100:DH1:FitPeak1:mu          2023-08-14 17:46:51.698989 5  
BL100:DH1:FitPeak1:mu          2023-08-14 17:47:11.818665 0  
BL100:DH1:FitPeak1:mu          2023-08-14 17:47:17.194963 5  
```

Since pydev.iointr was being called only with a value of 5, the value should have been only 5, but instead the behavior we see is that the value flips back and forth between 5 and 0. 

The issue seemed to go away when I added the mutex in the pull request. It seems to me like the issue happens when a callback is being scheduled and a callback is being run at the same time. 