### PR TITLE
Sequence inputs: handle by PySequence

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -2,7 +2,7 @@
 
 # Set this if you intend to build with a specific python version
 #   e.g. using python3
-# PYTHON_CONFIG=python3-config
+PYTHON_CONFIG=python3-config
 
 # Make any application-specific changes to the EPICS build
 #   configuration variables in this file.
@@ -35,3 +35,6 @@ CHECK_RELEASE = YES
 # You must rebuild in the iocBoot directory for this to
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+# Allow site specific changes that are not part of this repo
+-include $(TOP)/configure/RELEASE.local

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -37,4 +37,4 @@ CHECK_RELEASE = YES
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
 # Allow site specific changes that are not part of this repo
--include $(TOP)/configure/RELEASE.local
+-include $(TOP)/configure/CONFIG_SITE.local

--- a/iocBoot/iocpydev/st.cmd
+++ b/iocBoot/iocpydev/st.cmd
@@ -19,6 +19,7 @@ cd ${TOP}/iocBoot/${IOC}
 
 pydev("import time")
 pydev("import pydevtest")
+pydev("import numpy as np")
 pydev("google = pydevtest.HttpClient('www.google.com', 80)")
 
 iocInit

--- a/pycalcRecord.md
+++ b/pycalcRecord.md
@@ -86,7 +86,7 @@ pycalcRecord.dbd in the IOC as
 ### Simple expression
 
 ```
-record(py, "PyCalcTest:MathExpr") {
+record(pycalc, "PyCalcTest:MathExpr") {
     field(INPA, "17")
     field(INPB, "3")
     field(CALC, "A*B")
@@ -103,7 +103,7 @@ value for FTVL.
 ### Adaptive parameter and return value types
 
 ```
-record(py, "PyCalcTest:AdaptiveTypes") {
+record(pycalc, "PyCalcTest:AdaptiveTypes") {
     field(INPA, "PyCalcTest:Input1 CP")
     field(INPB, "PyCalcTest:Input2 CP")
     field(FTA,  "LONG")
@@ -122,7 +122,7 @@ is a double value, but we're only intersted in integer precision.
 ### Trigger record alarm
 
 ```
-record(py, "PyCalcTest:InvalidAlarm") {
+record(pycalc, "PyCalcTest:InvalidAlarm") {
     field(CALC, "unknown_function()")
 }
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,6 +31,7 @@ pydev_SRCS += pydev_stringin.cpp
 pydev_SRCS += pydev_stringout.cpp
 pydev_SRCS += pydev_waveform.cpp
 pydev_SRCS += pycalcRecord.cpp
+pydev_SRCS += variant.cpp
 
 # 3.15 and above support lsi, lso and printf records  
 ifdef BASE_3_15

--- a/src/pycalcRecord.cpp
+++ b/src/pycalcRecord.cpp
@@ -56,6 +56,8 @@ static long fetchValues(pycalcRecord *rec);
 struct PyCalcRecordContext {
     CALLBACK callback;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 rset pycalcRSET = {
@@ -136,130 +138,167 @@ static long initRecord(dbCommon *common, int pass)
 
 static void processRecordCb(pycalcRecord* rec)
 {
-    auto fields = Util::getFields(rec->calc);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    auto ctx = reinterpret_cast<PyCalcRecordContext*>(rec->ctx);
+    std::string code = rec->calc;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
         else {
             for (auto i = 0; i < PYCALCREC_NARGS; i++) {
                 std::string field = std::string(1,'A'+i);
-                if (keyval.first == field) {
+                if (macro == field) {
                     auto val = &rec->a   + i;
                     auto ft  = &rec->fta + i;
                     auto me  = &rec->mea + i;
                     auto ne  = &rec->nea + i;
 
+                    code = Util::replaceMacro(code, field, "pydev"+field);
                     if (*me == 1) {
-                        if      (*ft == DBR_CHAR)   keyval.second = std::to_string(*reinterpret_cast<   epicsInt8*>(*val));
-                        else if (*ft == DBR_UCHAR)  keyval.second = std::to_string(*reinterpret_cast<  epicsUInt8*>(*val));
-                        else if (*ft == DBR_SHORT)  keyval.second = std::to_string(*reinterpret_cast<  epicsInt16*>(*val));
-                        else if (*ft == DBR_USHORT) keyval.second = std::to_string(*reinterpret_cast< epicsUInt16*>(*val));
-                        else if (*ft == DBR_LONG)   keyval.second = std::to_string(*reinterpret_cast<  epicsInt32*>(*val));
-                        else if (*ft == DBR_ULONG)  keyval.second = std::to_string(*reinterpret_cast< epicsUInt32*>(*val));
+                        if      (*ft == DBR_CHAR)   { args["pydev"+field] = Variant(*reinterpret_cast<   epicsInt8*>(*val)); }
+                        else if (*ft == DBR_UCHAR)  { args["pydev"+field] = Variant(*reinterpret_cast<  epicsUInt8*>(*val)); }
+                        else if (*ft == DBR_SHORT)  { args["pydev"+field] = Variant(*reinterpret_cast<  epicsInt16*>(*val)); }
+                        else if (*ft == DBR_USHORT) { args["pydev"+field] = Variant(*reinterpret_cast< epicsUInt16*>(*val)); }
+                        else if (*ft == DBR_LONG)   { args["pydev"+field] = Variant(*reinterpret_cast<  epicsInt32*>(*val)); }
+                        else if (*ft == DBR_ULONG)  { args["pydev"+field] = Variant(*reinterpret_cast< epicsUInt32*>(*val)); }
 #ifdef HAVE_EPICS_INT64
-                        else if (*ft == DBR_INT64)  keyval.second = std::to_string(*reinterpret_cast<  epicsInt64*>(*val));
-                        else if (*ft == DBR_UINT64) keyval.second = std::to_string(*reinterpret_cast< epicsUInt64*>(*val));
+                        else if (*ft == DBR_INT64)  { args["pydev"+field] = Variant(*reinterpret_cast<  epicsInt64*>(*val)); }
+                        else if (*ft == DBR_UINT64) { args["pydev"+field] = Variant(*reinterpret_cast< epicsUInt64*>(*val)); }
 #endif
-                        else if (*ft == DBR_FLOAT)  keyval.second = std::to_string(*reinterpret_cast<epicsFloat32*>(*val));
-                        else if (*ft == DBR_DOUBLE) keyval.second = std::to_string(*reinterpret_cast<epicsFloat64*>(*val));
-                        else if (*ft == DBR_STRING) keyval.second = std::string(reinterpret_cast<const char*>(*val));
+                        else if (*ft == DBR_FLOAT)  { args["pydev"+field] = Variant(*reinterpret_cast<epicsFloat32*>(*val)); }
+                        else if (*ft == DBR_DOUBLE) { args["pydev"+field] = Variant(*reinterpret_cast<epicsFloat64*>(*val)); }
+                        else if (*ft == DBR_STRING) { args["pydev"+field] = Variant(*reinterpret_cast<        char*>(*val)); }
                     } else {
-                        if      (*ft == DBR_CHAR)   keyval.second = Util::to_pylist_string( reinterpret_cast<   epicsInt8*>(*val), *ne );
-                        else if (*ft == DBR_UCHAR)  keyval.second = Util::to_pylist_string( reinterpret_cast<  epicsUInt8*>(*val), *ne );
-                        else if (*ft == DBR_SHORT)  keyval.second = Util::to_pylist_string( reinterpret_cast<  epicsInt16*>(*val), *ne );
-                        else if (*ft == DBR_USHORT) keyval.second = Util::to_pylist_string( reinterpret_cast< epicsUInt16*>(*val), *ne );
-                        else if (*ft == DBR_LONG)   keyval.second = Util::to_pylist_string( reinterpret_cast<  epicsInt32*>(*val), *ne );
-                        else if (*ft == DBR_ULONG)  keyval.second = Util::to_pylist_string( reinterpret_cast< epicsUInt32*>(*val), *ne );
+                        if      (*ft == DBR_CHAR)   { auto a = reinterpret_cast<   epicsInt8*>(*val); args["pydev"+field] = Variant(a, *ne); }
+                        else if (*ft == DBR_UCHAR)  { auto a = reinterpret_cast<  epicsUInt8*>(*val); args["pydev"+field] = Variant(a, *ne); }
+                        else if (*ft == DBR_SHORT)  { auto a = reinterpret_cast<  epicsInt16*>(*val); args["pydev"+field] = Variant(a, *ne); }
+                        else if (*ft == DBR_USHORT) { auto a = reinterpret_cast< epicsUInt16*>(*val); args["pydev"+field] = Variant(a, *ne); }
+                        else if (*ft == DBR_LONG)   { auto a = reinterpret_cast<  epicsInt32*>(*val); args["pydev"+field] = Variant(a, *ne); }
+                        else if (*ft == DBR_ULONG)  { auto a = reinterpret_cast< epicsUInt32*>(*val); args["pydev"+field] = Variant(a, *ne); }
 #ifdef HAVE_EPICS_INT64
-                        else if (*ft == DBR_INT64)  keyval.second = Util::to_pylist_string( reinterpret_cast<  epicsInt64*>(*val), *ne );
-                        else if (*ft == DBR_UINT64) keyval.second = Util::to_pylist_string( reinterpret_cast< epicsUInt64*>(*val), *ne );
+                        else if (*ft == DBR_INT64)  { auto a = reinterpret_cast<  epicsInt64*>(*val); args["pydev"+field] = Variant(a, *ne); }
+                        else if (*ft == DBR_UINT64) { auto a = reinterpret_cast< epicsUInt64*>(*val); args["pydev"+field] = Variant(a, *ne); }
 #endif
-                        else if (*ft == DBR_FLOAT)  keyval.second = Util::to_pylist_string( reinterpret_cast<epicsFloat32*>(*val), *ne );
-                        else if (*ft == DBR_DOUBLE) keyval.second = Util::to_pylist_string( reinterpret_cast<epicsFloat64*>(*val), *ne );
+                        else if (*ft == DBR_FLOAT)  { auto a = reinterpret_cast<epicsFloat32*>(*val); args["pydev"+field] = Variant(a, *ne); }
+                        else if (*ft == DBR_DOUBLE) { auto a = reinterpret_cast<epicsFloat64*>(*val); args["pydev"+field] = Variant(a, *ne); }
                         else if (*ft == DBR_STRING) {
                             std::vector<std::string> a;
                             const char* ptr = reinterpret_cast<const char*>(*val);
                             for (size_t i=0; i<*ne; i++) {
                                 std::string element(ptr, dbValueSize(DBF_STRING));
                                 element.resize(element.find('\0'));
-                                a.push_back("'" + Util::escape(element) + "'");
+                                a.push_back(element);
                                 ptr += dbValueSize(DBF_STRING);
                             }
-                            keyval.second = Util::to_pylist_string(a);
+                            args["pydev"+field] = Variant(a);
                         }
                     }
                 }
             }
         }
     }
-    std::string code = Util::replaceFields(rec->calc, fields);
 
-    PyWrapper::MultiTypeValue ret;
-    long status = 0;
     try {
-        ret = PyWrapper::exec(code, (rec->tpro == 1));
-    } catch (...) {
-        status = -1;
-    }
-
-    rec->nevl = 0;
-    if (status == 0) {
-        typedef long (*convertRoutineCast)(const void*, void*, void*);
-        if (ret.type == PyWrapper::MultiTypeValue::Type::BOOL) {
-            epicsInt32 l = ret.b;
-            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_LONG][rec->ftvl]);
-            status = convert(&l, rec->val, 0);
-            rec->nevl = 1;
-        } else if (ret.type == PyWrapper::MultiTypeValue::Type::INTEGER) {
-            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_LONG][rec->ftvl]);
-            status = convert(&ret.i, rec->val, 0);
-            rec->nevl = 1;
-        } else if (ret.type == PyWrapper::MultiTypeValue::Type::FLOAT) {
-            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_DOUBLE][rec->ftvl]);
-            status = convert(&ret.f, rec->val, 0);
-            rec->nevl = 1;
-        } else if (ret.type == PyWrapper::MultiTypeValue::Type::STRING) {
-            char s[MAX_STRING_SIZE];
-            strncpy(s, ret.s.c_str(), MAX_STRING_SIZE);
-            s[MAX_STRING_SIZE-1] = 0;
-            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_STRING][rec->ftvl]);
-            status = convert(s, rec->val, 0);
-            rec->nevl = 1;
-        } else if (ret.type == PyWrapper::MultiTypeValue::Type::VECTOR_INTEGER) {
-            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_LONG][rec->ftvl]);
-            for (size_t i=0; i<ret.vi.size() && i<rec->mevl; i++) {
-                char* val = reinterpret_cast<char*>(rec->val) + i*dbValueSize(rec->ftvl);
-                status = convert(&ret.vi[i], val, 0);
-                if (status != 0) {
-                    break;
-                }
-                rec->nevl++;
-            }
-        } else if (ret.type == PyWrapper::MultiTypeValue::Type::VECTOR_FLOAT) {
-            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_DOUBLE][rec->ftvl]);
-            for (size_t i=0; i<ret.vf.size() && i<rec->mevl; i++) {
-                char* val = reinterpret_cast<char*>(rec->val) + i*dbValueSize(rec->ftvl);
-                status = convert(&ret.vf[i], val, 0);
-                if (status != 0) {
-                    break;
-                }
-                rec->nevl++;
-            }
-        } else if (ret.type == PyWrapper::MultiTypeValue::Type::VECTOR_STRING) {
-            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_STRING][rec->ftvl]);
-            for (size_t i=0; i<ret.vs.size() && i<rec->mevl; i++) {
-                char* val = reinterpret_cast<char*>(rec->val) + i*dbValueSize(rec->ftvl);
-                status = convert(ret.vs[i].c_str(), val, 0);
-                if (status != 0) {
-                    break;
-                }
-                rec->nevl++;
-            }
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
         }
+        auto ret = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1));
+
+        rec->nevl = 0;
+        typedef long (*convertRoutineCast)(const void*, void*, void*);
+        if (ret.type == Variant::Type::BOOL) {
+            epicsInt32 val = ret.get_bool();
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_LONG][rec->ftvl]);
+            if (convert(&val, rec->val, 0) != 0) {
+                throw Variant::ConvertError();
+            }
+            rec->nevl = 1;
+        } else if (ret.type == Variant::Type::LONG) {
+            epicsInt32 val = ret.get_long();
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_LONG][rec->ftvl]);
+            if (convert(&val, rec->val, 0) != 0) {
+                throw Variant::ConvertError();
+            }
+            rec->nevl = 1;
+        } else if (ret.type == Variant::Type::UNSIGNED) {
+            epicsInt32 val = ret.get_unsigned();
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_ULONG][rec->ftvl]);
+            if (convert(&val, rec->val, 0) != 0) {
+                throw Variant::ConvertError();
+            }
+            rec->nevl = 1;
+        } else if (ret.type == Variant::Type::DOUBLE) {
+            epicsFloat64 val = ret.get_double();
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_DOUBLE][rec->ftvl]);
+            if (convert(&val, rec->val, 0) != 0) {
+                throw Variant::ConvertError();
+            }
+            rec->nevl = 1;
+        } else if (ret.type == Variant::Type::STRING) {
+            char val[MAX_STRING_SIZE];
+            strncpy(val, ret.get_string().c_str(), MAX_STRING_SIZE);
+            val[MAX_STRING_SIZE-1] = 0;
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_STRING][rec->ftvl]);
+            if (convert(val, rec->val, 0) != 0) {
+                throw Variant::ConvertError();
+            }
+            rec->nevl = 1;
+        } else if (ret.type == Variant::Type::VECTOR_LONG) {
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_LONG][rec->ftvl]);
+            auto values = ret.get_long_array();
+            for (size_t i=0; i<values.size() && i<rec->mevl; i++) {
+                char* val = reinterpret_cast<char*>(rec->val) + i*dbValueSize(rec->ftvl);
+                if (convert(&values[i], val, 0) != 0) {
+                    throw Variant::ConvertError();
+                }
+                rec->nevl++;
+            }
+        } else if (ret.type == Variant::Type::VECTOR_UNSIGNED) {
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_ULONG][rec->ftvl]);
+            auto values = ret.get_unsigned_array();
+            for (size_t i=0; i<values.size() && i<rec->mevl; i++) {
+                char* val = reinterpret_cast<char*>(rec->val) + i*dbValueSize(rec->ftvl);
+                if (convert(&values[i], val, 0) != 0) {
+                    throw Variant::ConvertError();
+                }
+                rec->nevl++;
+            }
+        } else if (ret.type == Variant::Type::VECTOR_DOUBLE) {
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_DOUBLE][rec->ftvl]);
+            auto values = ret.get_double_array();
+            for (size_t i=0; i<values.size() && i<rec->mevl; i++) {
+                char* val = reinterpret_cast<char*>(rec->val) + i*dbValueSize(rec->ftvl);
+                if (convert(&values[i], val, 0) != 0) {
+                    throw Variant::ConvertError();
+                }
+                rec->nevl++;
+            }
+        } else if (ret.type == Variant::Type::VECTOR_STRING) {
+            auto convert = reinterpret_cast<convertRoutineCast>(dbFastPutConvertRoutine[DBF_STRING][rec->ftvl]);
+            auto values = ret.get_string_array();
+            for (size_t i=0; i<values.size() && i<rec->mevl; i++) {
+                char* val = reinterpret_cast<char*>(rec->val) + i*dbValueSize(rec->ftvl);
+                if (convert(values[i].c_str(), val, 0) != 0) {
+                    throw Variant::ConvertError();
+                }
+                rec->nevl++;
+            }
+        } else {
+            throw std::exception();
+        }
+        ctx->processCbStatus = 0;
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
+        recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
+        ctx->processCbStatus = -1;
     }
 
-    rec->ctx->processCbStatus = (status == 0 ? 0 : -1);
-    callbackRequestProcessCallback(&rec->ctx->callback, rec->prio, rec);
+    callbackRequestProcessCallback(&ctx->callback, rec->prio, rec);
 }
 
 static long processRecord(dbCommon *common)

--- a/src/pydev_ai.cpp
+++ b/src/pydev_ai.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -84,44 +86,43 @@ static void processRecordCb(aiRecord* rec)
     rec->val -= rec->aoff;
     if (rec->aslo != 0.0) rec->val /= rec->aslo;
 
-    auto fields = Util::getFields(rec->inp.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
-        else if (keyval.first == "ORAW") keyval.second = std::to_string(rec->oraw);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "EGU")  keyval.second = rec->egu;
-        else if (keyval.first == "HOPR") keyval.second = std::to_string(rec->hopr);
-        else if (keyval.first == "LOPR") keyval.second = std::to_string(rec->lopr);
-        else if (keyval.first == "PREC") keyval.second = std::to_string(rec->prec);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->inp.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "RVAL") { args["pydevRVAL"] = Variant(rec->rval); code = Util::replaceMacro(code, "RVAL", "pydevRVAL"); }
+        else if (macro == "ORAW") { args["pydevORAW"] = Variant(rec->oraw); code = Util::replaceMacro(code, "ORAW", "pydevORAW"); }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "EGU")  { args["pydevEGU"]  = Variant(rec->egu);  code = Util::replaceMacro(code, "EGU",  "pydevEGU");  }
+        else if (macro == "HOPR") { args["pydevHOPR"] = Variant(rec->hopr); code = Util::replaceMacro(code, "HOPR", "pydevHOPR"); }
+        else if (macro == "LOPR") { args["pydevLOPR"] = Variant(rec->lopr); code = Util::replaceMacro(code, "LOPR", "pydevLOPR"); }
+        else if (macro == "PREC") { args["pydevPREC"] = Variant(rec->prec); code = Util::replaceMacro(code, "PREC", "pydevPREC"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 
     try {
-        epicsFloat64 val;
-        if (PyWrapper::exec(code, (rec->tpro == 1), &val) == true) {
-            val = (val * rec->aslo) + rec->aoff;
-            if (rec->smoo == 0.0 || rec->udf)
-                rec->val = val;
-            else
-                rec->val = (rec->val * rec->smoo) + (val * (1.0 - rec->smoo));
-            rec->udf = 0;
-            ctx->processCbStatus = 0;
-        } else {
-            if (rec->tpro == 1) {
-                printf("ERROR: Can't convert returned Python type to double type\n");
-            }
-            recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
-            ctx->processCbStatus = -1;
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
         }
-    } catch (...) {
+        double val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_double();
+
+        val = (val * rec->aslo) + rec->aoff;
+        if (rec->smoo == 0.0 || rec->udf)
+            rec->val = val;
+        else
+            rec->val = (rec->val * rec->smoo) + (val * (1.0 - rec->smoo));
+        rec->udf = 0;
+        ctx->processCbStatus = 2; // Conversion already done
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }
-
-    if (ctx->processCbStatus == 0)
-        ctx->processCbStatus = 2; // Conversion already done
 
     callbackRequestProcessCallback(&ctx->callback, rec->prio, rec);
 }

--- a/src/pydev_ao.cpp
+++ b/src/pydev_ao.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -84,30 +86,36 @@ static void processRecordCb(aoRecord* rec)
     rec->val = rec->oval - rec->aoff;
     if (rec->aslo != 0.0) rec->val /= rec->aslo;
 
-    auto fields = Util::getFields(rec->out.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
-        else if (keyval.first == "ORAW") keyval.second = std::to_string(rec->oraw);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "EGU")  keyval.second = rec->egu;
-        else if (keyval.first == "HOPR") keyval.second = std::to_string(rec->hopr);
-        else if (keyval.first == "LOPR") keyval.second = std::to_string(rec->lopr);
-        else if (keyval.first == "PREC") keyval.second = std::to_string(rec->prec);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->out.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "RVAL") { args["pydevRVAL"] = Variant(rec->rval); code = Util::replaceMacro(code, "RVAL", "pydevRVAL"); }
+        else if (macro == "ORAW") { args["pydevORAW"] = Variant(rec->oraw); code = Util::replaceMacro(code, "ORAW", "pydevORAW"); }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "EGU")  { args["pydevEGU"]  = Variant(rec->egu);  code = Util::replaceMacro(code, "EGU",  "pydevEGU");  }
+        else if (macro == "HOPR") { args["pydevHOPR"] = Variant(rec->hopr); code = Util::replaceMacro(code, "HOPR", "pydevHOPR"); }
+        else if (macro == "LOPR") { args["pydevLOPR"] = Variant(rec->lopr); code = Util::replaceMacro(code, "LOPR", "pydevLOPR"); }
+        else if (macro == "PREC") { args["pydevPREC"] = Variant(rec->prec); code = Util::replaceMacro(code, "PREC", "pydevPREC"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 
     try {
-        epicsFloat64 val;
-        if (PyWrapper::exec(code, (rec->tpro == 1), &val) == true) {
-            rec->val = val;
-            if (rec->aslo != 0.0) rec->val *= rec->aslo;
-            rec->val += rec->aoff;
-            rec->udf = 0;
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
         }
+        rec->val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_double();
+        if (rec->aslo != 0.0) rec->val *= rec->aslo;
+        rec->val += rec->aoff;
+        rec->udf = 0;
         ctx->processCbStatus = 0;
-    } catch (...) {
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pydev_bi.cpp
+++ b/src/pydev_bi.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -81,28 +83,31 @@ static void processRecordCb(biRecord* rec)
 {
     auto ctx = reinterpret_cast<PyDevContext*>(rec->dpvt);
 
-    auto fields = Util::getFields(rec->inp.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "ZNAM") keyval.second = rec->znam;
-        else if (keyval.first == "ONAM") keyval.second = rec->onam;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->inp.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "RVAL") { args["pydevRVAL"] = Variant(rec->rval); code = Util::replaceMacro(code, "RVAL", "pydevRVAL"); }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "ZNAM") { args["pydevEGU"]  = Variant(rec->znam); code = Util::replaceMacro(code, "ZNAM", "pydevZNAM");  }
+        else if (macro == "ONAM") { args["pydevHOPR"] = Variant(rec->onam); code = Util::replaceMacro(code, "ONAM", "pydevONAM"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 
     try {
-        if (PyWrapper::exec(code, (rec->tpro == 1), &rec->rval) == true) {
-            ctx->processCbStatus = 0;
-        } else {
-            if (rec->tpro == 1) {
-                printf("ERROR: Can't convert returned Python type to record type\n");
-            }
-            recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
-            ctx->processCbStatus = -1;
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
         }
-    } catch (...) {
+        rec->rval = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_bool();
+        rec->udf = 0;
+        ctx->processCbStatus = 0;
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pydev_longout.cpp
+++ b/src/pydev_longout.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -81,25 +83,35 @@ static void processRecordCb(longoutRecord* rec)
 {
     auto ctx = reinterpret_cast<PyDevContext*>(rec->dpvt);
 
-    auto fields = Util::getFields(rec->out.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "EGU")  keyval.second = rec->egu;
-        else if (keyval.first == "HOPR") keyval.second = std::to_string(rec->hopr);
-        else if (keyval.first == "LOPR") keyval.second = std::to_string(rec->lopr);
-        else if (keyval.first == "HIGH") keyval.second = std::to_string(rec->high);
-        else if (keyval.first == "HIHI") keyval.second = std::to_string(rec->hihi);
-        else if (keyval.first == "LOW")  keyval.second = std::to_string(rec->low);
-        else if (keyval.first == "LOLO") keyval.second = std::to_string(rec->lolo);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->out.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "EGU")  { args["pydevEGU"]  = Variant(rec->egu);  code = Util::replaceMacro(code, "EGU",  "pydevEGU");  }
+        else if (macro == "HOPR") { args["pydevHOPR"] = Variant(rec->hopr); code = Util::replaceMacro(code, "HOPR", "pydevHOPR"); }
+        else if (macro == "LOPR") { args["pydevLOPR"] = Variant(rec->lopr); code = Util::replaceMacro(code, "LOPR", "pydevLOPR"); }
+        else if (macro == "HIGH") { args["pydevHIGH"] = Variant(rec->high); code = Util::replaceMacro(code, "HIGH", "pydevHIGH"); }
+        else if (macro == "HIHI") { args["pydevHIHI"] = Variant(rec->hihi); code = Util::replaceMacro(code, "HIHI", "pydevHIHI"); }
+        else if (macro == "LOW")  { args["pydevLOW"]  = Variant(rec->low);  code = Util::replaceMacro(code, "LOW",  "pydevLOW"); }
+        else if (macro == "LOLO") { args["pydevLOLO"] = Variant(rec->lolo); code = Util::replaceMacro(code, "LOLO", "pydevLOLO"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 
     try {
-        PyWrapper::exec(code, (rec->tpro == 1), &rec->val);
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
+        }
+        rec->val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_long();
+        rec->udf = 0;
         ctx->processCbStatus = 0;
-    } catch (...) {
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pydev_lsi.cpp
+++ b/src/pydev_lsi.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -81,31 +83,33 @@ static void processRecordCb(lsiRecord* rec)
 {
     auto ctx = reinterpret_cast<PyDevContext*>(rec->dpvt);
 
-    auto fields = Util::getFields(rec->inp.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = Util::escape(rec->val);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "SIZV") keyval.second = std::to_string(rec->sizv);
-        else if (keyval.first == "LEN")  keyval.second = std::to_string(rec->len);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->inp.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "SIZV") { args["pydevSIZV"] = Variant(rec->sizv); code = Util::replaceMacro(code, "SIZV", "pydevSIZV");  }
+        else if (macro == "LEN")  { args["pydevLEN"]  = Variant(rec->len);  code = Util::replaceMacro(code, "LEN",  "pydevLEN"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 
     try {
-        std::string val(rec->val);
-        if (PyWrapper::exec(code, (rec->tpro == 1), val) == true) {
-            strncpy(rec->val, val.c_str(), rec->sizv - 1);
-            rec->val[rec->sizv - 1] = 0;
-            rec->len = strlen(rec->val) + 1;
-            ctx->processCbStatus = 0;
-        } else {
-            if (rec->tpro == 1) {
-                printf("ERROR: Can't convert returned Python type to record type\n");
-            }
-            recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
-            ctx->processCbStatus = -1;
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
         }
-    } catch (...) {
+        std::string val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_string();
+        strncpy(rec->val, val.c_str(), rec->sizv - 1);
+        rec->val[rec->sizv - 1] = 0;
+        rec->len = strlen(rec->val) + 1;
+        rec->udf = 0;
+        ctx->processCbStatus = 0;
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pydev_lso.cpp
+++ b/src/pydev_lso.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -81,25 +83,33 @@ static void processRecordCb(lsoRecord* rec)
 {
     auto ctx = reinterpret_cast<PyDevContext*>(rec->dpvt);
 
-    auto fields = Util::getFields(rec->out.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = Util::escape(rec->val);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "SIZV") keyval.second = std::to_string(rec->sizv);
-        else if (keyval.first == "LEN")  keyval.second = std::to_string(rec->len);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->out.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "SIZV") { args["pydevSIZV"] = Variant(rec->sizv); code = Util::replaceMacro(code, "SIZV", "pydevSIZV");  }
+        else if (macro == "LEN")  { args["pydevLEN"]  = Variant(rec->len);  code = Util::replaceMacro(code, "LEN",  "pydevLEN"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 
     try {
-        std::string val(rec->val);
-        if (PyWrapper::exec(code, (rec->tpro == 1), val) == true) {
-            strncpy(rec->val, val.c_str(), rec->sizv - 1);
-            rec->val[rec->sizv - 1] = 0;
-            rec->len = strlen(rec->val) + 1;
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
         }
+        std::string val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_string();
+        strncpy(rec->val, val.c_str(), rec->sizv - 1);
+        rec->val[rec->sizv - 1] = 0;
+        rec->len = strlen(rec->val) + 1;
+        rec->udf = 0;
         ctx->processCbStatus = 0;
-    } catch (...) {
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pydev_mbbi.cpp
+++ b/src/pydev_mbbi.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -81,58 +83,61 @@ static void processRecordCb(mbbiRecord* rec)
 {
     auto ctx = reinterpret_cast<PyDevContext*>(rec->dpvt);
 
-    auto fields = Util::getFields(rec->inp.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "ZRVL") keyval.second = std::to_string(rec->zrvl);
-        else if (keyval.first == "ONVL") keyval.second = std::to_string(rec->onvl);
-        else if (keyval.first == "TWVL") keyval.second = std::to_string(rec->twvl);
-        else if (keyval.first == "THVL") keyval.second = std::to_string(rec->thvl);
-        else if (keyval.first == "FRVL") keyval.second = std::to_string(rec->frvl);
-        else if (keyval.first == "FVVL") keyval.second = std::to_string(rec->fvvl);
-        else if (keyval.first == "SXVL") keyval.second = std::to_string(rec->sxvl);
-        else if (keyval.first == "SVVL") keyval.second = std::to_string(rec->svvl);
-        else if (keyval.first == "EIVL") keyval.second = std::to_string(rec->eivl);
-        else if (keyval.first == "NIVL") keyval.second = std::to_string(rec->nivl);
-        else if (keyval.first == "TEVL") keyval.second = std::to_string(rec->tevl);
-        else if (keyval.first == "ELVL") keyval.second = std::to_string(rec->elvl);
-        else if (keyval.first == "TVVL") keyval.second = std::to_string(rec->tvvl);
-        else if (keyval.first == "TTVL") keyval.second = std::to_string(rec->ttvl);
-        else if (keyval.first == "FTVL") keyval.second = std::to_string(rec->ftvl);
-        else if (keyval.first == "FFVL") keyval.second = std::to_string(rec->ffvl);
-        else if (keyval.first == "ZRST") keyval.second = rec->zrst;
-        else if (keyval.first == "ONST") keyval.second = rec->onst;
-        else if (keyval.first == "TWST") keyval.second = rec->twst;
-        else if (keyval.first == "THST") keyval.second = rec->thst;
-        else if (keyval.first == "FRST") keyval.second = rec->frst;
-        else if (keyval.first == "FVST") keyval.second = rec->fvst;
-        else if (keyval.first == "SXST") keyval.second = rec->sxst;
-        else if (keyval.first == "SVST") keyval.second = rec->svst;
-        else if (keyval.first == "EIST") keyval.second = rec->eist;
-        else if (keyval.first == "NIST") keyval.second = rec->nist;
-        else if (keyval.first == "TEST") keyval.second = rec->test;
-        else if (keyval.first == "ELST") keyval.second = rec->elst;
-        else if (keyval.first == "TVST") keyval.second = rec->tvst;
-        else if (keyval.first == "TTST") keyval.second = rec->ttst;
-        else if (keyval.first == "FTST") keyval.second = rec->ftst;
-        else if (keyval.first == "FFST") keyval.second = rec->ffst;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->inp.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "RVAL") { args["pydevRVAL"] = Variant(rec->rval); code = Util::replaceMacro(code, "RVAL", "pydevRVAL"); }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "ZRVL") { args["pydevZRVL"] = Variant(rec->zrvl); code = Util::replaceMacro(code, "ZRVL", "pydevZRVL"); }
+        else if (macro == "ONVL") { args["pydevONVL"] = Variant(rec->onvl); code = Util::replaceMacro(code, "ONVL", "pydevONVL"); }
+        else if (macro == "TWVL") { args["pydevTWVL"] = Variant(rec->twvl); code = Util::replaceMacro(code, "TWVL", "pydevTWVL"); }
+        else if (macro == "THVL") { args["pydevTHVL"] = Variant(rec->thvl); code = Util::replaceMacro(code, "THVL", "pydevTHVL"); }
+        else if (macro == "FRVL") { args["pydevFRVL"] = Variant(rec->frvl); code = Util::replaceMacro(code, "FRVL", "pydevFRVL"); }
+        else if (macro == "FVVL") { args["pydevFVVL"] = Variant(rec->fvvl); code = Util::replaceMacro(code, "FVVL", "pydevFVVL"); }
+        else if (macro == "SXVL") { args["pydevSXVL"] = Variant(rec->sxvl); code = Util::replaceMacro(code, "SXVL", "pydevSXVL"); }
+        else if (macro == "SVVL") { args["pydevSVVL"] = Variant(rec->svvl); code = Util::replaceMacro(code, "SVVL", "pydevSVVL"); }
+        else if (macro == "EIVL") { args["pydevEIVL"] = Variant(rec->eivl); code = Util::replaceMacro(code, "EIVL", "pydevEIVL"); }
+        else if (macro == "NIVL") { args["pydevNIVL"] = Variant(rec->nivl); code = Util::replaceMacro(code, "NIVL", "pydevNIVL"); }
+        else if (macro == "TEVL") { args["pydevTEVL"] = Variant(rec->tevl); code = Util::replaceMacro(code, "TEVL", "pydevTEVL"); }
+        else if (macro == "ELVL") { args["pydevELVL"] = Variant(rec->elvl); code = Util::replaceMacro(code, "ELVL", "pydevELVL"); }
+        else if (macro == "TVVL") { args["pydevTVVL"] = Variant(rec->tvvl); code = Util::replaceMacro(code, "TVVL", "pydevTVVL"); }
+        else if (macro == "TTVL") { args["pydevTTVL"] = Variant(rec->ttvl); code = Util::replaceMacro(code, "TTVL", "pydevTTVL"); }
+        else if (macro == "FTVL") { args["pydevFTVL"] = Variant(rec->ftvl); code = Util::replaceMacro(code, "FTVL", "pydevFTVL"); }
+        else if (macro == "FFVL") { args["pydevFFVL"] = Variant(rec->ffvl); code = Util::replaceMacro(code, "FFVL", "pydevFFVL"); }
+        else if (macro == "ZRST") { args["pydevZRST"] = Variant(rec->zrst); code = Util::replaceMacro(code, "ZRST", "pydevZRST"); }
+        else if (macro == "ONST") { args["pydevONST"] = Variant(rec->onst); code = Util::replaceMacro(code, "ONST", "pydevONST"); }
+        else if (macro == "TWST") { args["pydevTWST"] = Variant(rec->twst); code = Util::replaceMacro(code, "TWST", "pydevTWST"); }
+        else if (macro == "THST") { args["pydevTHST"] = Variant(rec->thst); code = Util::replaceMacro(code, "THST", "pydevTHST"); }
+        else if (macro == "FRST") { args["pydevFRST"] = Variant(rec->frst); code = Util::replaceMacro(code, "FRST", "pydevFRST"); }
+        else if (macro == "FVST") { args["pydevFVST"] = Variant(rec->fvst); code = Util::replaceMacro(code, "FVST", "pydevFVST"); }
+        else if (macro == "SXST") { args["pydevSXST"] = Variant(rec->sxst); code = Util::replaceMacro(code, "SXST", "pydevSXST"); }
+        else if (macro == "SVST") { args["pydevSVST"] = Variant(rec->svst); code = Util::replaceMacro(code, "SVST", "pydevSVST"); }
+        else if (macro == "EIST") { args["pydevEIST"] = Variant(rec->eist); code = Util::replaceMacro(code, "EIST", "pydevEIST"); }
+        else if (macro == "NIST") { args["pydevNIST"] = Variant(rec->nist); code = Util::replaceMacro(code, "NIST", "pydevNIST"); }
+        else if (macro == "TEST") { args["pydevTEST"] = Variant(rec->test); code = Util::replaceMacro(code, "TEST", "pydevTEST"); }
+        else if (macro == "ELST") { args["pydevELST"] = Variant(rec->elst); code = Util::replaceMacro(code, "ELST", "pydevELST"); }
+        else if (macro == "TVST") { args["pydevTVST"] = Variant(rec->tvst); code = Util::replaceMacro(code, "TVST", "pydevTVST"); }
+        else if (macro == "TTST") { args["pydevTTST"] = Variant(rec->ttst); code = Util::replaceMacro(code, "TTST", "pydevTTST"); }
+        else if (macro == "FTST") { args["pydevFTST"] = Variant(rec->ftst); code = Util::replaceMacro(code, "FTST", "pydevFTST"); }
+        else if (macro == "FFST") { args["pydevFFST"] = Variant(rec->ffst); code = Util::replaceMacro(code, "FFST", "pydevFFST"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 
     try {
-        if (PyWrapper::exec(code, (rec->tpro == 1), &rec->rval) == true) {
-            ctx->processCbStatus = 0;
-        } else {
-            if (rec->tpro == 1) {
-                printf("ERROR: Can't convert returned Python type to record type\n");
-            }
-            recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
-            ctx->processCbStatus = -1;
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
         }
-    } catch (...) {
+        rec->val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_long();
+        rec->udf = 0;
+        ctx->processCbStatus = 0;
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pydev_mbbo.cpp
+++ b/src/pydev_mbbo.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -81,51 +83,61 @@ static void processRecordCb(mbboRecord* rec)
 {
     auto ctx = reinterpret_cast<PyDevContext*>(rec->dpvt);
 
-    auto fields = Util::getFields(rec->out.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "ZRVL") keyval.second = std::to_string(rec->zrvl);
-        else if (keyval.first == "ONVL") keyval.second = std::to_string(rec->onvl);
-        else if (keyval.first == "TWVL") keyval.second = std::to_string(rec->twvl);
-        else if (keyval.first == "THVL") keyval.second = std::to_string(rec->thvl);
-        else if (keyval.first == "FRVL") keyval.second = std::to_string(rec->frvl);
-        else if (keyval.first == "FVVL") keyval.second = std::to_string(rec->fvvl);
-        else if (keyval.first == "SXVL") keyval.second = std::to_string(rec->sxvl);
-        else if (keyval.first == "SVVL") keyval.second = std::to_string(rec->svvl);
-        else if (keyval.first == "EIVL") keyval.second = std::to_string(rec->eivl);
-        else if (keyval.first == "NIVL") keyval.second = std::to_string(rec->nivl);
-        else if (keyval.first == "TEVL") keyval.second = std::to_string(rec->tevl);
-        else if (keyval.first == "ELVL") keyval.second = std::to_string(rec->elvl);
-        else if (keyval.first == "TVVL") keyval.second = std::to_string(rec->tvvl);
-        else if (keyval.first == "TTVL") keyval.second = std::to_string(rec->ttvl);
-        else if (keyval.first == "FTVL") keyval.second = std::to_string(rec->ftvl);
-        else if (keyval.first == "FFVL") keyval.second = std::to_string(rec->ffvl);
-        else if (keyval.first == "ZRST") keyval.second = rec->zrst;
-        else if (keyval.first == "ONST") keyval.second = rec->onst;
-        else if (keyval.first == "TWST") keyval.second = rec->twst;
-        else if (keyval.first == "THST") keyval.second = rec->thst;
-        else if (keyval.first == "FRST") keyval.second = rec->frst;
-        else if (keyval.first == "FVST") keyval.second = rec->fvst;
-        else if (keyval.first == "SXST") keyval.second = rec->sxst;
-        else if (keyval.first == "SVST") keyval.second = rec->svst;
-        else if (keyval.first == "EIST") keyval.second = rec->eist;
-        else if (keyval.first == "NIST") keyval.second = rec->nist;
-        else if (keyval.first == "TEST") keyval.second = rec->test;
-        else if (keyval.first == "ELST") keyval.second = rec->elst;
-        else if (keyval.first == "TVST") keyval.second = rec->tvst;
-        else if (keyval.first == "TTST") keyval.second = rec->ttst;
-        else if (keyval.first == "FTST") keyval.second = rec->ftst;
-        else if (keyval.first == "FFST") keyval.second = rec->ffst;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->out.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "RVAL") { args["pydevRVAL"] = Variant(rec->rval); code = Util::replaceMacro(code, "RVAL", "pydevRVAL"); }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "ZRVL") { args["pydevZRVL"] = Variant(rec->zrvl); code = Util::replaceMacro(code, "ZRVL", "pydevZRVL"); }
+        else if (macro == "ONVL") { args["pydevONVL"] = Variant(rec->onvl); code = Util::replaceMacro(code, "ONVL", "pydevONVL"); }
+        else if (macro == "TWVL") { args["pydevTWVL"] = Variant(rec->twvl); code = Util::replaceMacro(code, "TWVL", "pydevTWVL"); }
+        else if (macro == "THVL") { args["pydevTHVL"] = Variant(rec->thvl); code = Util::replaceMacro(code, "THVL", "pydevTHVL"); }
+        else if (macro == "FRVL") { args["pydevFRVL"] = Variant(rec->frvl); code = Util::replaceMacro(code, "FRVL", "pydevFRVL"); }
+        else if (macro == "FVVL") { args["pydevFVVL"] = Variant(rec->fvvl); code = Util::replaceMacro(code, "FVVL", "pydevFVVL"); }
+        else if (macro == "SXVL") { args["pydevSXVL"] = Variant(rec->sxvl); code = Util::replaceMacro(code, "SXVL", "pydevSXVL"); }
+        else if (macro == "SVVL") { args["pydevSVVL"] = Variant(rec->svvl); code = Util::replaceMacro(code, "SVVL", "pydevSVVL"); }
+        else if (macro == "EIVL") { args["pydevEIVL"] = Variant(rec->eivl); code = Util::replaceMacro(code, "EIVL", "pydevEIVL"); }
+        else if (macro == "NIVL") { args["pydevNIVL"] = Variant(rec->nivl); code = Util::replaceMacro(code, "NIVL", "pydevNIVL"); }
+        else if (macro == "TEVL") { args["pydevTEVL"] = Variant(rec->tevl); code = Util::replaceMacro(code, "TEVL", "pydevTEVL"); }
+        else if (macro == "ELVL") { args["pydevELVL"] = Variant(rec->elvl); code = Util::replaceMacro(code, "ELVL", "pydevELVL"); }
+        else if (macro == "TVVL") { args["pydevTVVL"] = Variant(rec->tvvl); code = Util::replaceMacro(code, "TVVL", "pydevTVVL"); }
+        else if (macro == "TTVL") { args["pydevTTVL"] = Variant(rec->ttvl); code = Util::replaceMacro(code, "TTVL", "pydevTTVL"); }
+        else if (macro == "FTVL") { args["pydevFTVL"] = Variant(rec->ftvl); code = Util::replaceMacro(code, "FTVL", "pydevFTVL"); }
+        else if (macro == "FFVL") { args["pydevFFVL"] = Variant(rec->ffvl); code = Util::replaceMacro(code, "FFVL", "pydevFFVL"); }
+        else if (macro == "ZRST") { args["pydevZRST"] = Variant(rec->zrst); code = Util::replaceMacro(code, "ZRST", "pydevZRST"); }
+        else if (macro == "ONST") { args["pydevONST"] = Variant(rec->onst); code = Util::replaceMacro(code, "ONST", "pydevONST"); }
+        else if (macro == "TWST") { args["pydevTWST"] = Variant(rec->twst); code = Util::replaceMacro(code, "TWST", "pydevTWST"); }
+        else if (macro == "THST") { args["pydevTHST"] = Variant(rec->thst); code = Util::replaceMacro(code, "THST", "pydevTHST"); }
+        else if (macro == "FRST") { args["pydevFRST"] = Variant(rec->frst); code = Util::replaceMacro(code, "FRST", "pydevFRST"); }
+        else if (macro == "FVST") { args["pydevFVST"] = Variant(rec->fvst); code = Util::replaceMacro(code, "FVST", "pydevFVST"); }
+        else if (macro == "SXST") { args["pydevSXST"] = Variant(rec->sxst); code = Util::replaceMacro(code, "SXST", "pydevSXST"); }
+        else if (macro == "SVST") { args["pydevSVST"] = Variant(rec->svst); code = Util::replaceMacro(code, "SVST", "pydevSVST"); }
+        else if (macro == "EIST") { args["pydevEIST"] = Variant(rec->eist); code = Util::replaceMacro(code, "EIST", "pydevEIST"); }
+        else if (macro == "NIST") { args["pydevNIST"] = Variant(rec->nist); code = Util::replaceMacro(code, "NIST", "pydevNIST"); }
+        else if (macro == "TEST") { args["pydevTEST"] = Variant(rec->test); code = Util::replaceMacro(code, "TEST", "pydevTEST"); }
+        else if (macro == "ELST") { args["pydevELST"] = Variant(rec->elst); code = Util::replaceMacro(code, "ELST", "pydevELST"); }
+        else if (macro == "TVST") { args["pydevTVST"] = Variant(rec->tvst); code = Util::replaceMacro(code, "TVST", "pydevTVST"); }
+        else if (macro == "TTST") { args["pydevTTST"] = Variant(rec->ttst); code = Util::replaceMacro(code, "TTST", "pydevTTST"); }
+        else if (macro == "FTST") { args["pydevFTST"] = Variant(rec->ftst); code = Util::replaceMacro(code, "FTST", "pydevFTST"); }
+        else if (macro == "FFST") { args["pydevFFST"] = Variant(rec->ffst); code = Util::replaceMacro(code, "FFST", "pydevFFST"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 
     try {
-        PyWrapper::exec(code, (rec->tpro == 1), &rec->rval);
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
+        }
+        rec->val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_long();
+        rec->udf = 0;
         ctx->processCbStatus = 0;
-    } catch (...) {
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pydev_stringout.cpp
+++ b/src/pydev_stringout.cpp
@@ -24,6 +24,8 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
@@ -81,22 +83,30 @@ static void processRecordCb(stringoutRecord* rec)
 {
     auto ctx = reinterpret_cast<PyDevContext*>(rec->dpvt);
 
-    auto fields = Util::getFields(rec->out.value.instio.string);
-    for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = Util::escape(rec->val);
-        else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+    std::string code = rec->out.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if      (macro == "VAL")  { args["pydevVAL"]  = Variant(rec->val);  code = Util::replaceMacro(code, "VAL",  "pydevVAL");  }
+        else if (macro == "NAME") { args["pydevNAME"] = Variant(rec->name); code = Util::replaceMacro(code, "NAME", "pydevNAME"); }
+        else if (macro == "TPRO") { args["pydevTPRO"] = Variant(rec->tpro); code = Util::replaceMacro(code, "TPRO", "pydevTPRO"); }
     }
-    std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 
     try {
-        std::string val(rec->val);
-        if (PyWrapper::exec(code, (rec->tpro == 1), val) == true) {
-            strncpy(rec->val, val.c_str(), sizeof(rec->val)-1);
-            rec->val[sizeof(rec->val)-1] = 0;
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
         }
+        std::string val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_string();
+        strncpy(rec->val, val.c_str(), sizeof(rec->val)-1);
+        rec->val[sizeof(rec->val)-1] = 0;
+        rec->udf = 0;
         ctx->processCbStatus = 0;
-    } catch (...) {
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
+        }
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pydev_waveform.cpp
+++ b/src/pydev_waveform.cpp
@@ -25,66 +25,58 @@ struct PyDevContext {
     CALLBACK callback;
     IOSCANPVT scan;
     int processCbStatus;
+    std::string code;
+    PyWrapper::ByteCode bytecode;
 };
 
 static std::map<std::string, IOSCANPVT> ioScanPvts;
 
 template <typename T>
-static bool toRecArrayVal(waveformRecord* rec, const std::vector<T>& arr)
+static void toRecArrayVal(waveformRecord* rec, const std::vector<T>& arr)
 {
     if (rec->ftvl == menuFtypeCHAR) {
         auto val = reinterpret_cast<epicsInt8*>(rec->bptr);
         rec->nord = std::min(arr.size(), (size_t)rec->nelm);
         std::copy(arr.begin(), arr.begin()+rec->nord, val);
-        return true;
     } else if (rec->ftvl == menuFtypeUCHAR) {
         auto val = reinterpret_cast<epicsUInt8*>(rec->bptr);
         rec->nord = std::min(arr.size(), (size_t)rec->nelm);
         std::copy(arr.begin(), arr.begin()+rec->nord, val);
-        return true;
     } else if (rec->ftvl == menuFtypeSHORT) {
         auto val = reinterpret_cast<epicsInt16*>(rec->bptr);
         rec->nord = std::min(arr.size(), (size_t)rec->nelm);
         std::copy(arr.begin(), arr.begin()+rec->nord, val);
-        return true;
     } else if (rec->ftvl == menuFtypeUSHORT) {
         auto val = reinterpret_cast<epicsUInt16*>(rec->bptr);
         rec->nord = std::min(arr.size(), (size_t)rec->nelm);
         std::copy(arr.begin(), arr.begin()+rec->nord, val);
-        return true;
     } else if (rec->ftvl == menuFtypeLONG) {
         auto val = reinterpret_cast<epicsInt32*>(rec->bptr);
         rec->nord = std::min(arr.size(), (size_t)rec->nelm);
         std::copy(arr.begin(), arr.begin()+rec->nord, val);
-        return true;
     } else if (rec->ftvl == menuFtypeULONG) {
         auto val = reinterpret_cast<epicsUInt32*>(rec->bptr);
         rec->nord = std::min(arr.size(), (size_t)rec->nelm);
         std::copy(arr.begin(), arr.begin()+rec->nord, val);
-        return true;
     } else if (rec->ftvl == menuFtypeFLOAT) {
         auto val = reinterpret_cast<epicsFloat32*>(rec->bptr);
         rec->nord = std::min(arr.size(), (size_t)rec->nelm);
         std::copy(arr.begin(), arr.begin()+rec->nord, val);
-        return true;
     } else if (rec->ftvl == menuFtypeDOUBLE) {
         auto val = reinterpret_cast<epicsFloat64*>(rec->bptr);
         rec->nord = std::min(arr.size(), (size_t)rec->nelm);
         std::copy(arr.begin(), arr.begin()+rec->nord, val);
-        return true;
+    } else {
+        throw Variant::ConvertError();
     }
-    return false;
 }
 
 template <>
-bool toRecArrayVal<std::string>(waveformRecord* rec, const std::vector<std::string>& arr)
+void toRecArrayVal<std::string>(waveformRecord* rec, const std::vector<std::string>& arr)
 {
 
     if (!rec->ftvl == menuFtypeSTRING) {
-        if (rec->tpro) {
-            printf("Can not convert strings for record type %d\n", rec->ftvl);
-        }
-        return false;
+        throw Variant::ConvertError();
     }
 
     rec->nord = std::min(arr.size(), (size_t)rec->nelm);
@@ -109,8 +101,6 @@ bool toRecArrayVal<std::string>(waveformRecord* rec, const std::vector<std::stri
         std::copy(cval.begin(), cval.end(), cptr);
         cptr[MAX_STRING_SIZE - 1] = '\0'; /* sentinel */
     }
-
-    return true;
 }
 
 static void scanCallback(IOSCANPVT scan)
@@ -181,57 +171,66 @@ static void processRecordCb(waveformRecord* rec)
 {
     auto ctx = reinterpret_cast<PyDevContext*>(rec->dpvt);
 
-    auto fields = Util::getFields(rec->inp.value.instio.string);
-    for (auto& keyval: fields) {
-        if (keyval.first == "VAL") {
-
-            if      (rec->ftvl == menuFtypeCHAR)   keyval.second = Util::to_pylist_string( reinterpret_cast<   epicsInt8*>(rec->bptr), rec->nelm );
-            else if (rec->ftvl == menuFtypeUCHAR)  keyval.second = Util::to_pylist_string( reinterpret_cast<  epicsUInt8*>(rec->bptr), rec->nelm );
-            else if (rec->ftvl == menuFtypeSHORT)  keyval.second = Util::to_pylist_string( reinterpret_cast<  epicsInt16*>(rec->bptr), rec->nelm );
-            else if (rec->ftvl == menuFtypeUSHORT) keyval.second = Util::to_pylist_string( reinterpret_cast< epicsUInt16*>(rec->bptr), rec->nelm );
-            else if (rec->ftvl == menuFtypeLONG)   keyval.second = Util::to_pylist_string( reinterpret_cast<  epicsInt32*>(rec->bptr), rec->nelm );
-            else if (rec->ftvl == menuFtypeULONG)  keyval.second = Util::to_pylist_string( reinterpret_cast< epicsUInt32*>(rec->bptr), rec->nelm );
-            else if (rec->ftvl == menuFtypeFLOAT)  keyval.second = Util::to_pylist_string( reinterpret_cast<epicsFloat32*>(rec->bptr), rec->nelm );
-            else if (rec->ftvl == menuFtypeDOUBLE) keyval.second = Util::to_pylist_string( reinterpret_cast<epicsFloat64*>(rec->bptr), rec->nelm );
-            else if (rec->ftvl == menuFtypeSTRING) keyval.second = Util::to_pylist_string( reinterpret_cast<epicsFloat64*>(rec->bptr), rec->nelm );
+    std::string code = rec->inp.value.instio.string;
+    std::map<std::string, Variant> args;
+    for (auto& macro: Util::getMacros(code)) {
+        if (macro == "VAL")  {
+            std::vector<long long int> vl;
+            std::vector<double> vd;
+            std::vector<std::string> vs;
+            if      (rec->ftvl == menuFtypeCHAR)   { auto a = reinterpret_cast<epicsInt8*>(rec->bptr);    vl.assign(a, a+rec->nelm); }
+            else if (rec->ftvl == menuFtypeUCHAR)  { auto a = reinterpret_cast<epicsUInt8*>(rec->bptr);   vl.assign(a, a+rec->nelm); }
+            else if (rec->ftvl == menuFtypeSHORT)  { auto a = reinterpret_cast<epicsInt16*>(rec->bptr);   vl.assign(a, a+rec->nelm); }
+            else if (rec->ftvl == menuFtypeUSHORT) { auto a = reinterpret_cast<epicsUInt16*>(rec->bptr);  vl.assign(a, a+rec->nelm); }
+            else if (rec->ftvl == menuFtypeLONG)   { auto a = reinterpret_cast<epicsInt32*>(rec->bptr);   vl.assign(a, a+rec->nelm); }
+            else if (rec->ftvl == menuFtypeULONG)  { auto a = reinterpret_cast<epicsUInt32*>(rec->bptr);  vl.assign(a, a+rec->nelm); }
+            else if (rec->ftvl == menuFtypeFLOAT)  { auto a = reinterpret_cast<epicsFloat32*>(rec->bptr); vd.assign(a, a+rec->nelm); }
+            else if (rec->ftvl == menuFtypeDOUBLE) { auto a = reinterpret_cast<epicsFloat64*>(rec->bptr); vd.assign(a, a+rec->nelm); }
             else if (rec->ftvl == menuFtypeSTRING) {
-                std::vector<std::string> arr;
-                arr.resize(rec->nord);
-                auto val = reinterpret_cast<char*>(rec->bptr);
+                vs.resize(rec->nord);
+                auto a = reinterpret_cast<char*>(rec->bptr);
                 for(size_t i=0; i<rec->nord; ++i){
-                    const char *cptr = &val[i * MAX_STRING_SIZE];
-                    arr[i] = std::string(cptr, 0, MAX_STRING_SIZE);
+                    const char *cptr = &a[i * MAX_STRING_SIZE];
+                    vs[i] = std::string(cptr, 0, MAX_STRING_SIZE);
                 }
-                keyval.second = Util::to_pylist_string(arr);
             }
+
+            if (!vl.empty()) args["pydevVAL"] = Variant(vl);
+            if (!vd.empty()) args["pydevVAL"] = Variant(vd);
+            if (!vs.empty()) args["pydevVAL"] = Variant(vs);
+            code = Util::replaceMacro(code, "VAL", "pydevVAL");
+        } else if (macro == "TPRO") {
+            args["pydevTPRO"] = Variant(rec->tpro);
+            code = Util::replaceMacro(code, "TPRO", "pydevTPRO");
         }
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
     }
-    std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 
     try {
-        bool ret;
+        if (ctx->code != code) {
+            PyWrapper::destroy(std::move(ctx->bytecode));
+            ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
+            ctx->code = code;
+        }
+        auto val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1));
+
         if (rec->ftvl == menuFtypeFLOAT || rec->ftvl == menuFtypeDOUBLE) {
-            std::vector<double> arr;
-            ret = (PyWrapper::exec(code, (rec->tpro == 1), arr) && toRecArrayVal(rec, arr));
+            std::vector<double> arr = val.get_double_array();
+            toRecArrayVal(rec, arr);
         } else if (rec->ftvl == menuFtypeSTRING) {
-            std::vector<std::string> arr;
-            ret = (PyWrapper::exec(code, (rec->tpro == 1), arr) && toRecArrayVal(rec, arr));
+            std::vector<std::string> arr = val.get_string_array();
+            toRecArrayVal(rec, arr);
         } else {
-            std::vector<long> arr;
-            ret = (PyWrapper::exec(code, (rec->tpro == 1), arr) && toRecArrayVal(rec, arr));
+            std::vector<long long int> arr = val.get_long_array();
+            toRecArrayVal(rec, arr);
         }
 
-        if (ret == true) {
-            ctx->processCbStatus = 0;
-        } else {
-            if (rec->tpro == 1) {
-                printf("ERROR: Can't convert returned Python type to record type\n");
-            }
-            recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
-            ctx->processCbStatus = -1;
+        rec->udf = 0;
+        ctx->processCbStatus = 0;
+
+    } catch (std::exception& e) {
+        if (rec->tpro == 1) {
+            printf("[%s] %s\n", rec->name, e.what());
         }
-    } catch (...) {
         recGblSetSevr(rec, epicsAlarmCalc, epicsSevInvalid);
         ctx->processCbStatus = -1;
     }

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -270,14 +270,14 @@ bool PyWrapper::convert(void* in_, Variant& out)
         return true;
     }
 
-    if (PyList_Check(in)) {
+    if (PySequence_Check(in)) {
         std::vector<double> vd;
         std::vector<long long int> vl;
         std::vector<std::string> vs;
         Variant::Type t = Variant::Type::NONE;
 
-        for (Py_ssize_t i = 0; i < PyList_Size(in); i++) {
-            PyObject* el = PyList_GetItem(in, i);
+        for (Py_ssize_t i = 0; i < PySequence_Size(in); i++) {
+            PyObject* el = PySequence_GetItem(in, i);
 #if PY_MAJOR_VERSION < 3
             if (PyInt_Check(el) && (t == Variant::Type::NONE || t == Variant::Type::VECTOR_LONG)) {
                 long long val = PyInt_AsLong(el);

--- a/src/pywrapper.h
+++ b/src/pywrapper.h
@@ -6,42 +6,131 @@
 #ifndef PYWRAPPER_H
 #define PYWRAPPER_H
 
+#include "variant.h"
+
 #include <functional>
+#include <map>
 #include <string>
 #include <vector>
 
 class PyWrapper {
     public:
-        struct MultiTypeValue {
-            std::string s;
-            bool b;
-            double f;
-            long i;
-            std::vector<long> vi;
-            std::vector<double> vf;
-            std::vector<std::string> vs;
-            enum class Type {
-                NONE,
-                BOOL,
-                STRING,
-                FLOAT,
-                INTEGER,
-                VECTOR_FLOAT,
-                VECTOR_INTEGER,
-                VECTOR_STRING,
-            } type{Type::NONE};
+        class SyntaxError : public std::exception
+        {
+            public:
+                virtual const char* what() {
+                    return "Python Syntax Error";
+                }
+        };
+
+        class EvalError : public std::exception
+        {
+            public:
+                virtual const char* what() {
+                    return "Code Eval Error";
+                }
+        };
+
+        class ArgumentError : public std::exception
+        {
+            public:
+                virtual const char* what() {
+                    return "Argument Error";
+                }
+        };
+
+        struct ByteCode
+        {
+            private:
+                void* code;
+                ByteCode(void*);
+                ByteCode(ByteCode &) = delete;
+                ByteCode &operator=(const ByteCode &) = delete;
+                friend class PyWrapper;
+
+            public:
+                ByteCode();
+                ByteCode(ByteCode&&);
+                ByteCode& operator=(ByteCode&&);
+                ~ByteCode();
         };
         using Callback = std::function<void()>;
     private:
-        static bool convert(void* in, MultiTypeValue& out);
+        static bool convert(void* in, Variant& out);
     public:
         static bool init();
         static void shutdown();
         static void registerIoIntr(const std::string& name, const Callback& cb);
-        static MultiTypeValue exec(const std::string& line, bool debug);
-        static bool exec(const std::string& line, bool debug, std::string& val);
-        template <typename T> static bool exec(const std::string& line, bool debug, T* val);
-        template <typename T> static bool exec(const std::string& line, bool debug, std::vector<T>& val);
+
+        /**
+         * @brief Compile Python code into bytecode
+         * 
+         * Compiling Python code into intermediate bytecode allows performance
+         * gains when same code will be used many times. This will parse the
+         * code, but not actually evaluate it.
+         * This function runs under locked GIL environment.
+         * 
+         * @param code Python code to be compiled
+         * @param debug Prints errors to the EPICS console.
+         * @return ByteCode Compiled bytecode, must be destroyed after not used any more.
+         */
+        static ByteCode compile(const std::string &code, bool debug);
+
+        /**
+         * @brief Evaluate previously compiled bytecode and return result.
+         * 
+         * Evaluating previously compiled bytecode will run the code and
+         * optionally return the result.
+         * This function runs under locked GIL environment.
+         * 
+         * @param bytecode Previously compiled bytecode
+         * @param args Optional arguments passed to Python code, aka functions etc.
+         * @param debug Prints errors to the EPICS console.
+         * @return Variant 
+         */
+        static Variant eval(const ByteCode& bytecode, const std::map<std::string, Variant> &args, bool debug);
+
+        /**
+         * @brief Execute (compile and eval) given Python code
+         * 
+         * This is a convenience function that combines compiling Python
+         * code and immediately evaluating it. This is useful when the code
+         * is only specified once, for example when invoked from EPICS shell.
+         * 
+         * @param code Python code to be executed
+         * @param args Optional arguments to the Python function
+         * @param debug Prints errors to the EPICS console.
+         * @return Variant Value returned from Python code, if any.
+         */
+        static Variant exec(const std::string &code, const std::map<std::string, Variant> &args, bool debug);
+
+        /**
+         * @brief Execute (compile and eval) given Python code with no arguments.
+         * 
+         * This is a convenience function that combines compiling Python code
+         * and immediately evaluating it, and not arguments are needed.
+         * 
+         * @param code Python code to be executed
+         * @param debug Prints errors to the EPICS console.
+         * @return Variant Value returned from Python code, if any.
+         */
+        static Variant exec(const std::string &code, bool debug = false)
+        {
+            std::map<std::string, Variant> args;
+            return PyWrapper::exec(code, args, debug);
+        }
+
+        /**
+         * @brief Destroy previously compiled bytecode
+         * 
+         * As with any Python object, the compiled bytecode needs to be 
+         * dereferenced after use to free-up any memory it has been using.
+         * Dereferencing requires GIL to be obtained, and this function
+         * will guarantee that GIL is locked.
+         * 
+         * @param bytecode Previously compiled bytecode, may be empty object.
+         */
+        static void destroy(ByteCode&& bytecode);
 };
 
 #endif // PYWRAPPER_H

--- a/src/unittest/Makefile
+++ b/src/unittest/Makefile
@@ -19,6 +19,7 @@ TESTS += testutil
 TESTPROD_HOST += testpywrapper
 testpywrapper_SRCS += test_pywrapper.cpp
 testpywrapper_SRCS += pywrapper.cpp
+testpywrapper_SRCS += variant.cpp
 TESTS += testpywrapper
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)

--- a/src/unittest/test_pywrapper.cpp
+++ b/src/unittest/test_pywrapper.cpp
@@ -7,6 +7,16 @@
 #include <map>
 #include <string>
 
+#define testOkExcept1(a) { \
+    try { \
+        testOk1(a) \
+    } catch (...) { \
+        testFail("Exception by " #a) \
+    } \
+}
+
+#define testExcept(a) try { a; testFail("Test failed"); } catch (...) { testPass(#a " raised exception"); }
+
 struct TestPyWrapper {
     static void init()
     {
@@ -15,67 +25,69 @@ struct TestPyWrapper {
 
     static void returnFromEval()
     {
-        int32_t i;
-        double d;
-        std::string s;
-        char c;
-        std::vector<long> vi;
-        std::vector<double> vf;
+        testOk1(PyWrapper::exec("17").get_long() == 17);
+        testOk1(PyWrapper::exec("17").get_unsigned() == 17UL);
+        testOk1(PyWrapper::exec("17").get_double() == 17.0);
+        testOk1(PyWrapper::exec("17").get_string() == "17");
+        testExcept(PyWrapper::exec("17").get_long_array());
+        testExcept(PyWrapper::exec("17").get_double_array());
+        testExcept(PyWrapper::exec("17").get_unsigned_array());
+        testExcept(PyWrapper::exec("17").get_string_array());
 
-        testOk1(PyWrapper::exec("17", false, &i) == true && i == 17);
-        testOk1(PyWrapper::exec("17", false, &c) == true && c == 17);
-        testOk1(PyWrapper::exec("17", false, &d) == true && d == 17.0);
-        testOk1(PyWrapper::exec("17", false, s)  == true && s == "17");
-        testOk1(PyWrapper::exec("17", false, vi) == false);
-        testOk1(PyWrapper::exec("17", false, vf) == false);
+        testOk1(PyWrapper::exec("13.1").get_long() == 13);
+        testOk1(PyWrapper::exec("13.1").get_unsigned() == 13UL);
+        testOk1(PyWrapper::exec("13.1").get_double() == 13.1);
+        testOk1(PyWrapper::exec("13.1").get_string().substr(0,4) == "13.1");
+        testExcept(PyWrapper::exec("13.1").get_long_array());
+        testExcept(PyWrapper::exec("13.1").get_double_array());
+        testExcept(PyWrapper::exec("13.1").get_unsigned_array());
+        testExcept(PyWrapper::exec("13.1").get_string_array());
 
-        testOk1(PyWrapper::exec("13.0", false, &i) == true && i == 13);
-        testOk1(PyWrapper::exec("13.0", false, &c) == true && c == 13);
-        testOk1(PyWrapper::exec("13.0", false, &d) == true && d == 13.0);
-        testOk1(PyWrapper::exec("13.0", false,  s) == true && s.substr(0,4) == "13.0");
-        testOk1(PyWrapper::exec("13.0", false, vi) == false);
-        testOk1(PyWrapper::exec("13.0", false, vf) == false);
+        testOk1(PyWrapper::exec("True").get_long() == 1);
+        testOk1(PyWrapper::exec("True").get_unsigned() == 1UL);
+        testOk1(PyWrapper::exec("True").get_double() == 1.0);
+        testOk1(PyWrapper::exec("True").get_string() == "True");
+        testExcept(PyWrapper::exec("True").get_long_array());
+        testExcept(PyWrapper::exec("True").get_double_array());
+        testExcept(PyWrapper::exec("True").get_unsigned_array());
+        testExcept(PyWrapper::exec("True").get_string_array());
 
-        testOk1(PyWrapper::exec("True", false, &i) == true && i == 1);
-        testOk1(PyWrapper::exec("True", false, &c) == true && c == 1);
-        testOk1(PyWrapper::exec("True", false, &d) == true && d == 1.0);
-        testOk1(PyWrapper::exec("True", false,  s) == true && s == "1");
-        testOk1(PyWrapper::exec("True", false, vi) == false);
-        testOk1(PyWrapper::exec("True", false, vf) == false);
+        testOk1(PyWrapper::exec("'5.2'").get_long() == 5);
+        testOk1(PyWrapper::exec("'5.2'").get_unsigned() == 5UL);
+        testOk1(PyWrapper::exec("'5.2'").get_double() == 5.2);
+        testOk1(PyWrapper::exec("'5.2'").get_string().substr(0,3) == "5.2");
+        testExcept(PyWrapper::exec("'5.2'").get_long_array());
+        testExcept(PyWrapper::exec("'5.2'").get_unsigned_array());
+        testExcept(PyWrapper::exec("'5.2'").get_double_array());
+        testExcept(PyWrapper::exec("'5.2'").get_string_array());
 
-        testOk1(PyWrapper::exec("'5.2'", false, &i) == false);
-        testOk1(PyWrapper::exec("'5.2'", false, &c) == false);
-        testOk1(PyWrapper::exec("'5.2'", false, &d) == false);
-        testOk1(PyWrapper::exec("'5.2'", false, s)  == true && s == "5.2");
-        testOk1(PyWrapper::exec("'5.2'", false, vi) == false);
-        testOk1(PyWrapper::exec("'5.2'", false, vf) == false);
+        testExcept(PyWrapper::exec("a=12").get_long());
+        testExcept(PyWrapper::exec("a=12").get_unsigned());
+        testExcept(PyWrapper::exec("a=12").get_double());
+        testExcept(PyWrapper::exec("a=12").get_string());
+        testExcept(PyWrapper::exec("a=12").get_long_array());
+        testExcept(PyWrapper::exec("a=12").get_unsigned_array());
+        testExcept(PyWrapper::exec("a=12").get_double_array());
+        testExcept(PyWrapper::exec("a=12").get_string_array());
 
-        testOk1(PyWrapper::exec("a=12", false, &i) == false);
-        testOk1(PyWrapper::exec("a=12", false, &c) == false);
-        testOk1(PyWrapper::exec("a=12", false, &d) == false);
-        testOk1(PyWrapper::exec("a=12", false, s)  == false);
-        testOk1(PyWrapper::exec("a=12", false, vi) == false);
-        testOk1(PyWrapper::exec("a=12", false, vf) == false);
-
-        testOk1(PyWrapper::exec("[1,2,3]", false, &i) == false);
-        testOk1(PyWrapper::exec("[1,2,3]", false, &c) == false);
-        testOk1(PyWrapper::exec("[1,2,3]", false, &d) == false);
-        testOk1(PyWrapper::exec("[1,2,3]", false, s)  == false);
-        testOk1(PyWrapper::exec("[1,2,3]", false, vi) == true && vi.size() == 3 && vi[0] == 1   && vi[1] == 2   && vi[2] ==3);
-        testOk1(PyWrapper::exec("[1,2,3]", false, vf) == true && vf.size() == 3 && vf[0] == 1.0 && vf[1] == 2.0 && vf[2] ==3.0);
-
-        testOk1(PyWrapper::exec("[4.0,5.0]", false, &i) == false);
-        testOk1(PyWrapper::exec("[4.0,5.0]", false, &c) == false);
-        testOk1(PyWrapper::exec("[4.0,5.0]", false, &d) == false);
-        testOk1(PyWrapper::exec("[4.0,5.0]", false, s)  == false);
-        testOk1(PyWrapper::exec("[4.0,5.0]", false, vi) == true && vi.size() == 2 && vi[0] == 4   && vi[1] == 5);
-        testOk1(PyWrapper::exec("[4.0,5.0]", false, vf) == true && vf.size() == 2 && vf[0] == 4.0 && vf[1] == 5.0);
+        std::vector<long long int> cmplli = {1, 2, 3};
+        std::vector<unsigned long long int> cmpulli = {1UL, 2UL, 3UL};
+        std::vector<double> cmpd = {1.0, 2.0, 3.0};
+        std::vector<std::string> cmps = {"1", "2", "3"};
+        testExcept(PyWrapper::exec("[1,2,3]").get_long());
+        testExcept(PyWrapper::exec("[1,2,3]").get_unsigned());
+        testExcept(PyWrapper::exec("[1,2,3]").get_double());
+        testExcept(PyWrapper::exec("[1,2,3]").get_string());
+        testOk1(PyWrapper::exec("[1,2,3]").get_long_array() == cmplli);
+        testOk1(PyWrapper::exec("[1,2,3]").get_unsigned_array() == cmpulli);
+        testOk1(PyWrapper::exec("[1,2,3]").get_double_array() == cmpd);
+        testOk1(PyWrapper::exec("[1,2,3]").get_string_array() == cmps);
     }
 };
 
 MAIN(testpywrapper)
 {
-    testPlan(42);
+    testPlan(48);
 
     TestPyWrapper::init();
     TestPyWrapper::returnFromEval();

--- a/src/util.h
+++ b/src/util.h
@@ -12,44 +12,11 @@
 
 namespace Util {
 
-std::map<std::string, std::string> getFields(const std::string& text);
-std::string replaceFields(const std::string& text, const std::map<std::string, std::string>& fields);
+std::vector<std::string> getMacros(const std::string& text);
+std::string replaceMacro(const std::string& text, const std::string& macro, const std::string& replacement);
 std::string escape(const std::string& text);
 std::string join(const std::vector<std::string>& tokens, const std::string& glue);
 long getEnvConfig(const std::string& name, long defval);
-
-template <typename T>
-std::vector<std::string> to_strings(const T* array, size_t n)
-{
-    std::vector<std::string> values;
-    for (size_t i=0; i<n; i++) {
-        values.push_back(std::to_string(array[i]));
-    }
-    return values;
-}
-
-template <typename T>
-std::string to_pylist_string(const T* array, size_t n)
-{
-    auto values = to_strings(array, n);
-    return "[" + join(values, ",") + "]";
-}
-
-static inline std::string to_pylist_string(const std::vector<std::string>& array)
-{
-    return "[" + join(array, ",") + "]";
-}
-
-template<typename T, typename... Rest>
-struct is_any : std::false_type {};
-
-template<typename T, typename First>
-struct is_any<T, First> : std::is_same<T, First> {};
-
-template<typename T, typename First, typename... Rest>
-struct is_any<T, First, Rest...>
-    : std::integral_constant<bool, std::is_same<T, First>::value || is_any<T, Rest...>::value>
-{};
 
 };
 

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -1,0 +1,246 @@
+#include "variant.h"
+
+#include <stdexcept>
+
+Variant::Variant()
+    : type(Type::NONE)
+{}
+
+Variant::Variant(const std::string& val)
+    : s(val)
+    , type(Type::STRING)
+{}
+
+Variant::Variant(const bool val)
+    : b(val)
+    , type(Type::BOOL)
+{}
+
+Variant::Variant(const double val)
+    : d(val)
+    , type(Type::DOUBLE)
+{}
+
+Variant::Variant(const long long int val)
+    : l(val)
+    , type(Type::LONG)
+{}
+
+Variant::Variant(const unsigned long long int val)
+    : u(val)
+    , type(Type::UNSIGNED)
+{}
+
+Variant::Variant(const std::vector<long long int>& val)
+    : vl(val)
+    , type(Type::VECTOR_LONG)
+{}
+
+Variant::Variant(const std::vector<unsigned long long int>& val)
+    : vu(val)
+    , type(Type::VECTOR_UNSIGNED)
+{}
+
+Variant::Variant(const std::vector<double> &val)
+    : vd(val)
+    , type(Type::VECTOR_DOUBLE)
+{}
+
+Variant::Variant(const std::vector<std::string> &val)
+    : vs(val)
+    , type(Type::VECTOR_STRING)
+{}
+
+bool Variant::get_bool() const
+{
+    if (type == Type::BOOL) {
+        return b;
+    } else if (type == Type::LONG) {
+        return (l != 0);
+    } else if (type == Type::UNSIGNED) {
+        return (u != 0);
+    } else if (type == Type::DOUBLE) {
+        return (d != 0.0);
+    } else {
+        throw ConvertError();
+    }
+}
+
+int64_t Variant::get_long() const
+{
+    if (type == Type::BOOL) {
+        return (b ? 1 : 0);
+    } else if (type == Type::LONG) {
+        return l;
+    } else if (type == Type::UNSIGNED) {
+        return u;
+    } else if (type == Type::DOUBLE) {
+        return d;
+    } else if (type == Type::STRING) {
+        return std::stoll(s);
+    } else {
+        throw ConvertError();
+    }
+}
+
+uint64_t Variant::get_unsigned() const
+{
+    if (type == Type::BOOL) {
+        return (b ? 1 : 0);
+    } else if (type == Type::LONG) {
+        return l;
+    } else if (type == Type::UNSIGNED) {
+        return u;
+    } else if (type == Type::DOUBLE) {
+        return d;
+    } else if (type == Type::STRING) {
+        return std::stoull(s);
+    } else {
+        throw ConvertError();
+    }
+}
+
+double Variant::get_double() const
+{
+    if (type == Type::BOOL) {
+        return (b ? 1.0 : 0.0);
+    } else if (type == Type::LONG) {
+        return l;
+    } else if (type == Type::UNSIGNED) {
+        return u;
+    } else if (type == Type::DOUBLE) {
+        return d;
+    } else if (type == Type::STRING) {
+        return std::stod(s);
+    } else {
+        throw ConvertError();
+    }
+}
+
+std::string Variant::get_string() const
+{
+    if (type == Type::BOOL) {
+        return (b ? "True" : "False");
+    } else if (type == Type::LONG) {
+        return std::to_string(l);
+    } else if (type == Type::UNSIGNED) {
+        return std::to_string(u);
+    } else if (type == Type::DOUBLE) {
+        return std::to_string(d);
+    } else if (type == Type::STRING) {
+        return s;
+    } else {
+        throw ConvertError();
+    }
+}
+
+std::vector<long long int> Variant::get_long_array() const
+{
+    if (type == Type::VECTOR_LONG) {
+        return vl;
+    } else if (type == Type::VECTOR_UNSIGNED) {
+        std::vector<long long int> out;
+        for (auto& v: vu) {
+            out.push_back(v);
+        }
+        return out;
+    } else if (type == Type::VECTOR_DOUBLE) {
+        std::vector<long long int> out;
+        for (auto& v: vd) {
+            out.push_back(v);
+        }
+        return out;
+    } else if (type == Type::VECTOR_STRING) {
+        std::vector<long long int> out;
+        for (auto& v: vs) {
+            out.push_back(std::stoll(v));
+        }
+        return out;
+    } else {
+        throw ConvertError();
+    }
+}
+
+std::vector<unsigned long long int> Variant::get_unsigned_array() const
+{
+    if (type == Type::VECTOR_LONG) {
+        std::vector<unsigned long long int> out;
+        for (auto& v: vl) {
+            out.push_back(v);
+        }
+        return out;
+    } else if (type == Type::VECTOR_UNSIGNED) {
+        return vu;
+    } else if (type == Type::VECTOR_DOUBLE) {
+        std::vector<unsigned long long int> out;
+        for (auto& v: vd) {
+            out.push_back(v);
+        }
+        return out;
+    } else if (type == Type::VECTOR_STRING) {
+        std::vector<unsigned long long int> out;
+        for (auto& v: vs) {
+            out.push_back(std::stoull(v));
+        }
+        return out;
+    } else {
+        throw ConvertError();
+    }
+}
+
+std::vector<double> Variant::get_double_array() const
+{
+    if (type == Type::VECTOR_LONG) {
+        std::vector<double> out;
+        for (auto& v: vl) {
+            out.push_back(v);
+        }
+        return out;
+    } else if (type == Type::VECTOR_UNSIGNED) {
+        std::vector<double> out;
+        for (auto& v: vu) {
+            out.push_back(v);
+        }
+        return out;
+    } else if (type == Type::VECTOR_DOUBLE) {
+        return vd;
+    } else if (type == Type::VECTOR_STRING) {
+        std::vector<double> out;
+        for (auto& v: vs) {
+            out.push_back(std::stod(v));
+        }
+        return out;
+    } else {
+        throw ConvertError();
+    }
+}
+
+std::vector<std::string> Variant::get_string_array() const
+{
+    if (type == Type::VECTOR_LONG) {
+        std::vector<std::string> out;
+        for (auto& v: vl) {
+            out.push_back(std::to_string(v));
+        }
+        return out;
+    } else if (type == Type::VECTOR_UNSIGNED) {
+        std::vector<std::string> out;
+        for (auto& v: vu) {
+            out.push_back(std::to_string(v));
+        }
+        return out;
+    } else if (type == Type::VECTOR_DOUBLE) {
+        std::vector<std::string> out;
+        for (auto& v: vd) {
+            out.push_back(std::to_string(v));
+        }
+        return out;
+    } else if (type == Type::VECTOR_STRING) {
+        return vs;
+    } else {
+        throw ConvertError();
+    }
+}
+/*
+    std::vector<std::string> get_string_array() const;
+*/

--- a/src/variant.h
+++ b/src/variant.h
@@ -60,21 +60,21 @@ public:
     Variant(const std::vector<std::string>& val);
 
     // Helper c'tors for EPICS types
-    Variant(const char val)               : Variant(static_cast<const long long int>(val)){};
-    Variant(const short int val)          : Variant(static_cast<const long long int>(val)){};
-    Variant(const int val)                : Variant(static_cast<const long long int>(val)){};
-    Variant(const long int val)           : Variant(static_cast<const long long int>(val)){};
+    Variant(const signed char val)        : Variant(static_cast<const long long int>(val)){};
+    Variant(const signed short int val)   : Variant(static_cast<const long long int>(val)){};
+    Variant(const signed int val)         : Variant(static_cast<const long long int>(val)){};
+    Variant(const signed long int val)    : Variant(static_cast<const long long int>(val)){};
     Variant(const unsigned char val)      : Variant(static_cast<const unsigned long long int>(val)){};
     Variant(const unsigned short int val) : Variant(static_cast<const unsigned long long int>(val)){};
     Variant(const unsigned int val)       : Variant(static_cast<const unsigned long long int>(val)){};
     Variant(const unsigned long int val)  : Variant(static_cast<const unsigned long long int>(val)){};
     Variant(const float val)              : Variant(static_cast<const double>(val)){};
 
-    Variant(const char* vals,                   size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
-    Variant(const short int* vals,              size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
-    Variant(const int* vals,                    size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
-    Variant(const long int* vals,               size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
-    Variant(const long long int* vals,          size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const signed char* vals,            size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const signed short int* vals,       size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const signed int* vals,             size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const signed long int* vals,        size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const signed long long int* vals,   size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
     Variant(const unsigned char* vals,          size_t n) : Variant(std::vector<unsigned long long int>(vals, vals+n)) {};
     Variant(const unsigned short int* vals,     size_t n) : Variant(std::vector<unsigned long long int>(vals, vals+n)) {};
     Variant(const unsigned int* vals,           size_t n) : Variant(std::vector<unsigned long long int>(vals, vals+n)) {};

--- a/src/variant.h
+++ b/src/variant.h
@@ -1,0 +1,97 @@
+/*************************************************************************\
+* PyDevice is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef VARIANT_H
+#define VARIANT_H
+
+#include <epicsTypes.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class Variant
+{
+private:
+    std::string s;
+    bool b;
+    double d;
+    long long l;
+    unsigned long long u;
+    std::vector<long long int> vl;
+    std::vector<unsigned long long int> vu;
+    std::vector<double> vd;
+    std::vector<std::string> vs;
+
+public:
+    enum class Type
+    {
+        NONE,
+        BOOL,
+        STRING,
+        DOUBLE,
+        LONG,
+        UNSIGNED,
+        VECTOR_DOUBLE,
+        VECTOR_LONG,
+        VECTOR_UNSIGNED,
+        VECTOR_STRING,
+    } type{Type::NONE};
+
+    class ConvertError : public std::exception
+    {
+        public:
+            virtual const char* what() {
+                return "Failed to convert value";
+            }
+    };
+
+    Variant();
+    Variant(const std::string& val);
+    Variant(const bool val);
+    Variant(const long long int val);
+    Variant(const unsigned long long int val);
+    Variant(const double val);
+    Variant(const std::vector<long long int>& val);
+    Variant(const std::vector<unsigned long long int>& val);
+    Variant(const std::vector<double>& val);
+    Variant(const std::vector<std::string>& val);
+
+    // Helper c'tors for EPICS types
+    Variant(const char val)               : Variant(static_cast<const long long int>(val)){};
+    Variant(const short int val)          : Variant(static_cast<const long long int>(val)){};
+    Variant(const int val)                : Variant(static_cast<const long long int>(val)){};
+    Variant(const long int val)           : Variant(static_cast<const long long int>(val)){};
+    Variant(const unsigned char val)      : Variant(static_cast<const unsigned long long int>(val)){};
+    Variant(const unsigned short int val) : Variant(static_cast<const unsigned long long int>(val)){};
+    Variant(const unsigned int val)       : Variant(static_cast<const unsigned long long int>(val)){};
+    Variant(const unsigned long int val)  : Variant(static_cast<const unsigned long long int>(val)){};
+    Variant(const float val)              : Variant(static_cast<const double>(val)){};
+
+    Variant(const char* vals,                   size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const short int* vals,              size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const int* vals,                    size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const long int* vals,               size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const long long int* vals,          size_t n) : Variant(std::vector<long long int>(vals, vals+n)) {};
+    Variant(const unsigned char* vals,          size_t n) : Variant(std::vector<unsigned long long int>(vals, vals+n)) {};
+    Variant(const unsigned short int* vals,     size_t n) : Variant(std::vector<unsigned long long int>(vals, vals+n)) {};
+    Variant(const unsigned int* vals,           size_t n) : Variant(std::vector<unsigned long long int>(vals, vals+n)) {};
+    Variant(const unsigned long int* vals,      size_t n) : Variant(std::vector<unsigned long long int>(vals, vals+n)) {};
+    Variant(const unsigned long long int* vals, size_t n) : Variant(std::vector<unsigned long long int>(vals, vals+n)) {};
+    Variant(const float* vals,                  size_t n) : Variant(std::vector<double>(vals, vals+n)) {};
+    Variant(const double* vals,                 size_t n) : Variant(std::vector<double>(vals, vals+n)) {};
+
+    bool get_bool() const;
+    int64_t get_long() const;
+    uint64_t get_unsigned() const;
+    double get_double() const;
+    std::string get_string() const;
+    std::vector<long long int> get_long_array() const;
+    std::vector<unsigned long long int> get_unsigned_array() const;
+    std::vector<double> get_double_array() const;
+    std::vector<std::string> get_string_array() const;
+};
+
+#endif // VARIANT_H

--- a/testApp/Db/pycalcrectest.db
+++ b/testApp/Db/pycalcrectest.db
@@ -31,6 +31,15 @@ record(waveform, "PyCalcTest:InputNumbers") {
     # Only works with EPICS 7.0.2+
     field(INP,  [1.7, 2.3, 14.91])
 }
+
+record(waveform, "PyCalcTest:InputArray") {
+    field(FTVL, "DOUBLE")
+    field(NELM, "3")
+    # Only works with EPICS 7.0.2+
+    field(INP,  np.array([1.7, 2.3, 14.91]))
+    field(TRPO, 1)
+    field(PINI, "1")
+}
 record(waveform, "PyCalcTest:InputStrings") {
     field(FTVL, "STRING")
     field(NELM, "3")


### PR DESCRIPTION
Comment to https://github.com/klemenv/PyDevice/issues/19

Input sequences could be used by the more flexible sequence interface. Then records can pass any sequence as waveform 
inputs. This was tested for lists an numpy arrays

For large arrays please consider: the input is still processed to a list of strings which is then interpreted again by python. Here one should review if it would be more appropriate to use PyArray_SimpleNewFromData (see https://numpy.org/doc/stable/reference/c-api/array.html#creating-arrays). In that manner only an object would be passed to the user. This object would then directly access the array within the record.

Further discussion on converting float to strings is given in https://github.com/klemenv/PyDevice/pull/28
