### PR TITLE
Double input arguments: converting all digits (cleaner pull request)

### DIFF
--- a/src/pycalcRecord.cpp
+++ b/src/pycalcRecord.cpp
@@ -139,7 +139,7 @@ static void processRecordCb(pycalcRecord* rec)
     auto fields = Util::getFields(rec->calc);
     for (auto& keyval: fields) {
         if      (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
         else {
             for (auto i = 0; i < PYCALCREC_NARGS; i++) {
                 std::string field = std::string(1,'A'+i);
@@ -150,18 +150,18 @@ static void processRecordCb(pycalcRecord* rec)
                     auto ne  = &rec->nea + i;
 
                     if (*me == 1) {
-                        if      (*ft == DBR_CHAR)   keyval.second = std::to_string(*reinterpret_cast<   epicsInt8*>(*val));
-                        else if (*ft == DBR_UCHAR)  keyval.second = std::to_string(*reinterpret_cast<  epicsUInt8*>(*val));
-                        else if (*ft == DBR_SHORT)  keyval.second = std::to_string(*reinterpret_cast<  epicsInt16*>(*val));
-                        else if (*ft == DBR_USHORT) keyval.second = std::to_string(*reinterpret_cast< epicsUInt16*>(*val));
-                        else if (*ft == DBR_LONG)   keyval.second = std::to_string(*reinterpret_cast<  epicsInt32*>(*val));
-                        else if (*ft == DBR_ULONG)  keyval.second = std::to_string(*reinterpret_cast< epicsUInt32*>(*val));
+                        if      (*ft == DBR_CHAR)   keyval.second = Util::to_string(*reinterpret_cast<   epicsInt8*>(*val));
+                        else if (*ft == DBR_UCHAR)  keyval.second = Util::to_string(*reinterpret_cast<  epicsUInt8*>(*val));
+                        else if (*ft == DBR_SHORT)  keyval.second = Util::to_string(*reinterpret_cast<  epicsInt16*>(*val));
+                        else if (*ft == DBR_USHORT) keyval.second = Util::to_string(*reinterpret_cast< epicsUInt16*>(*val));
+                        else if (*ft == DBR_LONG)   keyval.second = Util::to_string(*reinterpret_cast<  epicsInt32*>(*val));
+                        else if (*ft == DBR_ULONG)  keyval.second = Util::to_string(*reinterpret_cast< epicsUInt32*>(*val));
 #ifdef HAVE_EPICS_INT64
-                        else if (*ft == DBR_INT64)  keyval.second = std::to_string(*reinterpret_cast<  epicsInt64*>(*val));
-                        else if (*ft == DBR_UINT64) keyval.second = std::to_string(*reinterpret_cast< epicsUInt64*>(*val));
+                        else if (*ft == DBR_INT64)  keyval.second = Util::to_string(*reinterpret_cast<  epicsInt64*>(*val));
+                        else if (*ft == DBR_UINT64) keyval.second = Util::to_string(*reinterpret_cast< epicsUInt64*>(*val));
 #endif
-                        else if (*ft == DBR_FLOAT)  keyval.second = std::to_string(*reinterpret_cast<epicsFloat32*>(*val));
-                        else if (*ft == DBR_DOUBLE) keyval.second = std::to_string(*reinterpret_cast<epicsFloat64*>(*val));
+                        else if (*ft == DBR_FLOAT)  keyval.second = Util::to_string(*reinterpret_cast<epicsFloat32*>(*val));
+                        else if (*ft == DBR_DOUBLE) keyval.second = Util::to_string(*reinterpret_cast<epicsFloat64*>(*val));
                         else if (*ft == DBR_STRING) keyval.second = std::string(reinterpret_cast<const char*>(*val));
                     } else {
                         if      (*ft == DBR_CHAR)   keyval.second = Util::to_pylist_string( reinterpret_cast<   epicsInt8*>(*val), *ne );

--- a/src/pydev_ai.cpp
+++ b/src/pydev_ai.cpp
@@ -86,15 +86,15 @@ static void processRecordCb(aiRecord* rec)
 
     auto fields = Util::getFields(rec->inp.value.instio.string);
     for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
-        else if (keyval.first == "ORAW") keyval.second = std::to_string(rec->oraw);
+        if      (keyval.first == "VAL")  keyval.second = Util::to_string(rec->val);
+        else if (keyval.first == "RVAL") keyval.second = Util::to_string(rec->rval);
+        else if (keyval.first == "ORAW") keyval.second = Util::to_string(rec->oraw);
         else if (keyval.first == "NAME") keyval.second = rec->name;
         else if (keyval.first == "EGU")  keyval.second = rec->egu;
-        else if (keyval.first == "HOPR") keyval.second = std::to_string(rec->hopr);
-        else if (keyval.first == "LOPR") keyval.second = std::to_string(rec->lopr);
-        else if (keyval.first == "PREC") keyval.second = std::to_string(rec->prec);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "HOPR") keyval.second = Util::to_string(rec->hopr);
+        else if (keyval.first == "LOPR") keyval.second = Util::to_string(rec->lopr);
+        else if (keyval.first == "PREC") keyval.second = Util::to_string(rec->prec);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 

--- a/src/pydev_ao.cpp
+++ b/src/pydev_ao.cpp
@@ -86,15 +86,15 @@ static void processRecordCb(aoRecord* rec)
 
     auto fields = Util::getFields(rec->out.value.instio.string);
     for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
-        else if (keyval.first == "ORAW") keyval.second = std::to_string(rec->oraw);
+        if      (keyval.first == "VAL")  keyval.second = Util::to_string(rec->val);
+        else if (keyval.first == "RVAL") keyval.second = Util::to_string(rec->rval);
+        else if (keyval.first == "ORAW") keyval.second = Util::to_string(rec->oraw);
         else if (keyval.first == "NAME") keyval.second = rec->name;
         else if (keyval.first == "EGU")  keyval.second = rec->egu;
-        else if (keyval.first == "HOPR") keyval.second = std::to_string(rec->hopr);
-        else if (keyval.first == "LOPR") keyval.second = std::to_string(rec->lopr);
-        else if (keyval.first == "PREC") keyval.second = std::to_string(rec->prec);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "HOPR") keyval.second = Util::to_string(rec->hopr);
+        else if (keyval.first == "LOPR") keyval.second = Util::to_string(rec->lopr);
+        else if (keyval.first == "PREC") keyval.second = Util::to_string(rec->prec);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 

--- a/src/pydev_bi.cpp
+++ b/src/pydev_bi.cpp
@@ -83,12 +83,12 @@ static void processRecordCb(biRecord* rec)
 
     auto fields = Util::getFields(rec->inp.value.instio.string);
     for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
+        if      (keyval.first == "VAL")  keyval.second = Util::to_string(rec->val);
+        else if (keyval.first == "RVAL") keyval.second = Util::to_string(rec->rval);
         else if (keyval.first == "NAME") keyval.second = rec->name;
         else if (keyval.first == "ZNAM") keyval.second = rec->znam;
         else if (keyval.first == "ONAM") keyval.second = rec->onam;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 

--- a/src/pydev_bo.cpp
+++ b/src/pydev_bo.cpp
@@ -83,12 +83,12 @@ static void processRecordCb(boRecord* rec)
 
     auto fields = Util::getFields(rec->out.value.instio.string);
     for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
+        if      (keyval.first == "VAL")  keyval.second = Util::to_string(rec->val);
+        else if (keyval.first == "RVAL") keyval.second = Util::to_string(rec->rval);
         else if (keyval.first == "NAME") keyval.second = rec->name;
         else if (keyval.first == "ZNAM") keyval.second = rec->znam;
         else if (keyval.first == "ONAM") keyval.second = rec->onam;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 

--- a/src/pydev_longin.cpp
+++ b/src/pydev_longin.cpp
@@ -83,16 +83,16 @@ static void processRecordCb(longinRecord* rec)
 
     auto fields = Util::getFields(rec->inp.value.instio.string);
     for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
+        if      (keyval.first == "VAL")  keyval.second = Util::to_string(rec->val);
         else if (keyval.first == "NAME") keyval.second = rec->name;
         else if (keyval.first == "EGU")  keyval.second = rec->egu;
-        else if (keyval.first == "HOPR") keyval.second = std::to_string(rec->hopr);
-        else if (keyval.first == "LOPR") keyval.second = std::to_string(rec->lopr);
-        else if (keyval.first == "HIGH") keyval.second = std::to_string(rec->high);
-        else if (keyval.first == "HIHI") keyval.second = std::to_string(rec->hihi);
-        else if (keyval.first == "LOW")  keyval.second = std::to_string(rec->low);
-        else if (keyval.first == "LOLO") keyval.second = std::to_string(rec->lolo);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "HOPR") keyval.second = Util::to_string(rec->hopr);
+        else if (keyval.first == "LOPR") keyval.second = Util::to_string(rec->lopr);
+        else if (keyval.first == "HIGH") keyval.second = Util::to_string(rec->high);
+        else if (keyval.first == "HIHI") keyval.second = Util::to_string(rec->hihi);
+        else if (keyval.first == "LOW")  keyval.second = Util::to_string(rec->low);
+        else if (keyval.first == "LOLO") keyval.second = Util::to_string(rec->lolo);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 

--- a/src/pydev_longout.cpp
+++ b/src/pydev_longout.cpp
@@ -83,16 +83,16 @@ static void processRecordCb(longoutRecord* rec)
 
     auto fields = Util::getFields(rec->out.value.instio.string);
     for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
+        if      (keyval.first == "VAL")  keyval.second = Util::to_string(rec->val);
         else if (keyval.first == "NAME") keyval.second = rec->name;
         else if (keyval.first == "EGU")  keyval.second = rec->egu;
-        else if (keyval.first == "HOPR") keyval.second = std::to_string(rec->hopr);
-        else if (keyval.first == "LOPR") keyval.second = std::to_string(rec->lopr);
-        else if (keyval.first == "HIGH") keyval.second = std::to_string(rec->high);
-        else if (keyval.first == "HIHI") keyval.second = std::to_string(rec->hihi);
-        else if (keyval.first == "LOW")  keyval.second = std::to_string(rec->low);
-        else if (keyval.first == "LOLO") keyval.second = std::to_string(rec->lolo);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "HOPR") keyval.second = Util::to_string(rec->hopr);
+        else if (keyval.first == "LOPR") keyval.second = Util::to_string(rec->lopr);
+        else if (keyval.first == "HIGH") keyval.second = Util::to_string(rec->high);
+        else if (keyval.first == "HIHI") keyval.second = Util::to_string(rec->hihi);
+        else if (keyval.first == "LOW")  keyval.second = Util::to_string(rec->low);
+        else if (keyval.first == "LOLO") keyval.second = Util::to_string(rec->lolo);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 

--- a/src/pydev_lsi.cpp
+++ b/src/pydev_lsi.cpp
@@ -85,9 +85,9 @@ static void processRecordCb(lsiRecord* rec)
     for (auto& keyval: fields) {
         if      (keyval.first == "VAL")  keyval.second = Util::escape(rec->val);
         else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "SIZV") keyval.second = std::to_string(rec->sizv);
-        else if (keyval.first == "LEN")  keyval.second = std::to_string(rec->len);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "SIZV") keyval.second = Util::to_string(rec->sizv);
+        else if (keyval.first == "LEN")  keyval.second = Util::to_string(rec->len);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 

--- a/src/pydev_lso.cpp
+++ b/src/pydev_lso.cpp
@@ -85,9 +85,9 @@ static void processRecordCb(lsoRecord* rec)
     for (auto& keyval: fields) {
         if      (keyval.first == "VAL")  keyval.second = Util::escape(rec->val);
         else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "SIZV") keyval.second = std::to_string(rec->sizv);
-        else if (keyval.first == "LEN")  keyval.second = std::to_string(rec->len);
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "SIZV") keyval.second = Util::to_string(rec->sizv);
+        else if (keyval.first == "LEN")  keyval.second = Util::to_string(rec->len);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 

--- a/src/pydev_mbbi.cpp
+++ b/src/pydev_mbbi.cpp
@@ -83,25 +83,25 @@ static void processRecordCb(mbbiRecord* rec)
 
     auto fields = Util::getFields(rec->inp.value.instio.string);
     for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
+        if      (keyval.first == "VAL")  keyval.second = Util::to_string(rec->val);
+        else if (keyval.first == "RVAL") keyval.second = Util::to_string(rec->rval);
         else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "ZRVL") keyval.second = std::to_string(rec->zrvl);
-        else if (keyval.first == "ONVL") keyval.second = std::to_string(rec->onvl);
-        else if (keyval.first == "TWVL") keyval.second = std::to_string(rec->twvl);
-        else if (keyval.first == "THVL") keyval.second = std::to_string(rec->thvl);
-        else if (keyval.first == "FRVL") keyval.second = std::to_string(rec->frvl);
-        else if (keyval.first == "FVVL") keyval.second = std::to_string(rec->fvvl);
-        else if (keyval.first == "SXVL") keyval.second = std::to_string(rec->sxvl);
-        else if (keyval.first == "SVVL") keyval.second = std::to_string(rec->svvl);
-        else if (keyval.first == "EIVL") keyval.second = std::to_string(rec->eivl);
-        else if (keyval.first == "NIVL") keyval.second = std::to_string(rec->nivl);
-        else if (keyval.first == "TEVL") keyval.second = std::to_string(rec->tevl);
-        else if (keyval.first == "ELVL") keyval.second = std::to_string(rec->elvl);
-        else if (keyval.first == "TVVL") keyval.second = std::to_string(rec->tvvl);
-        else if (keyval.first == "TTVL") keyval.second = std::to_string(rec->ttvl);
-        else if (keyval.first == "FTVL") keyval.second = std::to_string(rec->ftvl);
-        else if (keyval.first == "FFVL") keyval.second = std::to_string(rec->ffvl);
+        else if (keyval.first == "ZRVL") keyval.second = Util::to_string(rec->zrvl);
+        else if (keyval.first == "ONVL") keyval.second = Util::to_string(rec->onvl);
+        else if (keyval.first == "TWVL") keyval.second = Util::to_string(rec->twvl);
+        else if (keyval.first == "THVL") keyval.second = Util::to_string(rec->thvl);
+        else if (keyval.first == "FRVL") keyval.second = Util::to_string(rec->frvl);
+        else if (keyval.first == "FVVL") keyval.second = Util::to_string(rec->fvvl);
+        else if (keyval.first == "SXVL") keyval.second = Util::to_string(rec->sxvl);
+        else if (keyval.first == "SVVL") keyval.second = Util::to_string(rec->svvl);
+        else if (keyval.first == "EIVL") keyval.second = Util::to_string(rec->eivl);
+        else if (keyval.first == "NIVL") keyval.second = Util::to_string(rec->nivl);
+        else if (keyval.first == "TEVL") keyval.second = Util::to_string(rec->tevl);
+        else if (keyval.first == "ELVL") keyval.second = Util::to_string(rec->elvl);
+        else if (keyval.first == "TVVL") keyval.second = Util::to_string(rec->tvvl);
+        else if (keyval.first == "TTVL") keyval.second = Util::to_string(rec->ttvl);
+        else if (keyval.first == "FTVL") keyval.second = Util::to_string(rec->ftvl);
+        else if (keyval.first == "FFVL") keyval.second = Util::to_string(rec->ffvl);
         else if (keyval.first == "ZRST") keyval.second = rec->zrst;
         else if (keyval.first == "ONST") keyval.second = rec->onst;
         else if (keyval.first == "TWST") keyval.second = rec->twst;
@@ -118,7 +118,7 @@ static void processRecordCb(mbbiRecord* rec)
         else if (keyval.first == "TTST") keyval.second = rec->ttst;
         else if (keyval.first == "FTST") keyval.second = rec->ftst;
         else if (keyval.first == "FFST") keyval.second = rec->ffst;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 

--- a/src/pydev_mbbo.cpp
+++ b/src/pydev_mbbo.cpp
@@ -83,25 +83,25 @@ static void processRecordCb(mbboRecord* rec)
 
     auto fields = Util::getFields(rec->out.value.instio.string);
     for (auto& keyval: fields) {
-        if      (keyval.first == "VAL")  keyval.second = std::to_string(rec->val);
-        else if (keyval.first == "RVAL") keyval.second = std::to_string(rec->rval);
+        if      (keyval.first == "VAL")  keyval.second = Util::to_string(rec->val);
+        else if (keyval.first == "RVAL") keyval.second = Util::to_string(rec->rval);
         else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "ZRVL") keyval.second = std::to_string(rec->zrvl);
-        else if (keyval.first == "ONVL") keyval.second = std::to_string(rec->onvl);
-        else if (keyval.first == "TWVL") keyval.second = std::to_string(rec->twvl);
-        else if (keyval.first == "THVL") keyval.second = std::to_string(rec->thvl);
-        else if (keyval.first == "FRVL") keyval.second = std::to_string(rec->frvl);
-        else if (keyval.first == "FVVL") keyval.second = std::to_string(rec->fvvl);
-        else if (keyval.first == "SXVL") keyval.second = std::to_string(rec->sxvl);
-        else if (keyval.first == "SVVL") keyval.second = std::to_string(rec->svvl);
-        else if (keyval.first == "EIVL") keyval.second = std::to_string(rec->eivl);
-        else if (keyval.first == "NIVL") keyval.second = std::to_string(rec->nivl);
-        else if (keyval.first == "TEVL") keyval.second = std::to_string(rec->tevl);
-        else if (keyval.first == "ELVL") keyval.second = std::to_string(rec->elvl);
-        else if (keyval.first == "TVVL") keyval.second = std::to_string(rec->tvvl);
-        else if (keyval.first == "TTVL") keyval.second = std::to_string(rec->ttvl);
-        else if (keyval.first == "FTVL") keyval.second = std::to_string(rec->ftvl);
-        else if (keyval.first == "FFVL") keyval.second = std::to_string(rec->ffvl);
+        else if (keyval.first == "ZRVL") keyval.second = Util::to_string(rec->zrvl);
+        else if (keyval.first == "ONVL") keyval.second = Util::to_string(rec->onvl);
+        else if (keyval.first == "TWVL") keyval.second = Util::to_string(rec->twvl);
+        else if (keyval.first == "THVL") keyval.second = Util::to_string(rec->thvl);
+        else if (keyval.first == "FRVL") keyval.second = Util::to_string(rec->frvl);
+        else if (keyval.first == "FVVL") keyval.second = Util::to_string(rec->fvvl);
+        else if (keyval.first == "SXVL") keyval.second = Util::to_string(rec->sxvl);
+        else if (keyval.first == "SVVL") keyval.second = Util::to_string(rec->svvl);
+        else if (keyval.first == "EIVL") keyval.second = Util::to_string(rec->eivl);
+        else if (keyval.first == "NIVL") keyval.second = Util::to_string(rec->nivl);
+        else if (keyval.first == "TEVL") keyval.second = Util::to_string(rec->tevl);
+        else if (keyval.first == "ELVL") keyval.second = Util::to_string(rec->elvl);
+        else if (keyval.first == "TVVL") keyval.second = Util::to_string(rec->tvvl);
+        else if (keyval.first == "TTVL") keyval.second = Util::to_string(rec->ttvl);
+        else if (keyval.first == "FTVL") keyval.second = Util::to_string(rec->ftvl);
+        else if (keyval.first == "FFVL") keyval.second = Util::to_string(rec->ffvl);
         else if (keyval.first == "ZRST") keyval.second = rec->zrst;
         else if (keyval.first == "ONST") keyval.second = rec->onst;
         else if (keyval.first == "TWST") keyval.second = rec->twst;
@@ -118,7 +118,7 @@ static void processRecordCb(mbboRecord* rec)
         else if (keyval.first == "TTST") keyval.second = rec->ttst;
         else if (keyval.first == "FTST") keyval.second = rec->ftst;
         else if (keyval.first == "FFST") keyval.second = rec->ffst;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 

--- a/src/pydev_stringin.cpp
+++ b/src/pydev_stringin.cpp
@@ -85,7 +85,7 @@ static void processRecordCb(stringinRecord* rec)
     for (auto& keyval: fields) {
         if      (keyval.first == "VAL")  keyval.second = Util::escape(rec->val);
         else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 

--- a/src/pydev_stringout.cpp
+++ b/src/pydev_stringout.cpp
@@ -85,7 +85,7 @@ static void processRecordCb(stringoutRecord* rec)
     for (auto& keyval: fields) {
         if      (keyval.first == "VAL")  keyval.second = Util::escape(rec->val);
         else if (keyval.first == "NAME") keyval.second = rec->name;
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->out.value.instio.string, fields);
 

--- a/src/pydev_waveform.cpp
+++ b/src/pydev_waveform.cpp
@@ -205,7 +205,7 @@ static void processRecordCb(waveformRecord* rec)
                 keyval.second = Util::to_pylist_string(arr);
             }
         }
-        else if (keyval.first == "TPRO") keyval.second = std::to_string(rec->tpro);
+        else if (keyval.first == "TPRO") keyval.second = Util::to_string(rec->tpro);
     }
     std::string code = Util::replaceFields(rec->inp.value.instio.string, fields);
 

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -359,13 +359,13 @@ bool PyWrapper::exec(const std::string& line, bool debug, std::string& val)
         val = out.s;
         return true;
     case MultiTypeValue::Type::INTEGER:
-        val = std::to_string(out.i);
+        val = Util::to_string(out.i);
         return true;
     case MultiTypeValue::Type::FLOAT:
-        val = std::to_string(out.f);
+        val = Util::to_string(out.f);
         return true;
     case MultiTypeValue::Type::BOOL:
-        val = std::to_string(out.b);
+        val = Util::to_string(out.b);
         return true;
     default:
         return false;

--- a/src/unittest/Makefile
+++ b/src/unittest/Makefile
@@ -19,9 +19,9 @@ TESTS += testutil
 TESTPROD_HOST += testpywrapper
 testpywrapper_SRCS += test_pywrapper.cpp
 testpywrapper_SRCS += pywrapper.cpp
+testpywrapper_SRCS += util.cpp
 TESTS += testpywrapper
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 
 include $(TOP)/configure/RULES
-

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6,7 +6,11 @@
 #include "util.h"
 #include <envDefs.h>
 #include <cctype>
+#include <cfloat>
+#include <iomanip>
+#include <sstream>
 #include <stdexcept>
+
 
 namespace Util {
 
@@ -118,10 +122,11 @@ std::string join(const std::vector<std::string>& tokens, const std::string& glue
     return out.substr(0, out.length() - glue.length());
 }
 
+
 long getEnvConfig(const std::string& name, long defval)
 {
     long value = defval;
-    std::string sdefval = std::to_string(defval);
+    std::string sdefval = Util::to_string(defval);
     ENV_PARAM param{const_cast<char*>(name.c_str()), const_cast<char*>(sdefval.c_str())};
     envGetLongConfigParam(&param, &value);
     if (value < 1) {
@@ -130,5 +135,19 @@ long getEnvConfig(const std::string& name, long defval)
 
     return value;
 }
+
+namespace detail {
+template <typename T>
+static std::string floating_point_to_string(const T v, const int digits)
+{
+    std::stringstream strm;
+    strm << std::scientific << std::setprecision(digits + 1) << v;
+    return strm.str();
+}
+} // namespace detail
+
+std::string detail::float_to_string(const float v){ return detail::floating_point_to_string(v, FLT_DIG); }
+std::string detail::double_to_string(const double v){ return detail::floating_point_to_string(v, DBL_DIG); }
+std::string detail::long_double_to_string(const long double v){ return detail::floating_point_to_string(v, LDBL_DIG); }
 
 }; // namespace Util

--- a/src/util.h
+++ b/src/util.h
@@ -18,12 +18,30 @@ std::string escape(const std::string& text);
 std::string join(const std::vector<std::string>& tokens, const std::string& glue);
 long getEnvConfig(const std::string& name, long defval);
 
+namespace detail {
+// conversion from python basis types to strings
+// std::to_string has only limited accuracy for floot double etc.
+std::string float_to_string(const float v);
+std::string double_to_string(const double v);
+std::string long_double_to_string(const long double v);
+}
+
+// defined inline to avoid definition of function in different sub-objects.
+template<typename T>
+inline std::string to_string(const T v) { return std::to_string(v); }
+template<>
+inline std::string to_string(const float v) { return detail::float_to_string(v); }
+template<>
+inline std::string to_string(const double v) { return detail::double_to_string(v); }
+template<>
+inline std::string to_string(const long double v) { return detail::long_double_to_string(v); }
+
 template <typename T>
 std::vector<std::string> to_strings(const T* array, size_t n)
 {
     std::vector<std::string> values;
     for (size_t i=0; i<n; i++) {
-        values.push_back(std::to_string(array[i]));
+        values.push_back(Util::to_string(array[i]));
     }
     return values;
 }


### PR DESCRIPTION
This PR supersedes https://github.com/klemenv/PyDevice/pull/28 

Before input arguments are handled to python these arguments are converted to strings. From my tests I saw that std::to_string uses a fixed field of roughly 6 digits. This can result in a loss of conversion accuracy: e.g epsilon values
passed as limits to an internal optimiser can be 1e-6 or 1e-8. This value would be passed as "zero" to python.

A solution could be a redirection: provide a template function

```c++
template <typename T>
 inline std::string to_string(const T v) { return std::to_string(v); }
```

with special implementations for float, double and long double. These convert the number to string
streaming it to a string buffer using appropriate io manipulation.

I replaced all calls to std::to_string in the wrappers of all the different epics types; even for those that do 
not need that change. In my opinion it makes the overall code cleaner, as when "std::to_string" is good enough 
is only handled within utils.h