### PR TITLE
Fix memory leak in PyWrapper::eval when args contains vectors

### DIFF
--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -389,29 +389,37 @@ Variant PyWrapper::eval(const PyWrapper::ByteCode& bytecode, const std::map<std:
             item = PyList_New(0);
             auto vals = keyval.second.get_long_array();
             for (auto& val: vals) {
-                PyList_Append(item, PyLong_FromLongLong(val));
+                PyObject* element = PyLong_FromLongLong(val);
+                PyList_Append(item, element);
+                Py_DECREF(element);
             }
         } else if (keyval.second.type == Variant::Type::VECTOR_UNSIGNED) {
             item = PyList_New(0);
             auto vals = keyval.second.get_unsigned_array();
             for (auto& val: vals) {
-                PyList_Append(item, PyLong_FromUnsignedLongLong(val));
+                PyObject* element = PyLong_FromUnsignedLongLong(val);
+                PyList_Append(item, element);
+                Py_DECREF(element);
             }
         } else if (keyval.second.type == Variant::Type::VECTOR_DOUBLE) {
             item = PyList_New(0);
             auto vals = keyval.second.get_double_array();
             for (auto& val: vals) {
-                PyList_Append(item, PyFloat_FromDouble(val));
+                PyObject* element = PyFloat_FromDouble(val);
+                PyList_Append(item, element);
+                Py_DECREF(element);
             }
         } else if (keyval.second.type == Variant::Type::VECTOR_STRING) {
             item = PyList_New(0);
             auto vals = keyval.second.get_string_array();
             for (auto& val: vals) {
 #if PY_MAJOR_VERSION < 3
-                PyList_Append(item, PyString_FromString(val.c_str()));
+                PyObject* element = PyString_FromString(val.c_str());
 #else
-                PyList_Append(item, PyUnicode_FromString(val.c_str()));
+                PyObject* element = PyUnicode_FromString(val.c_str());
 #endif
+                PyList_Append(item, element);
+                Py_DECREF(element);
             }
         }
         if (item == nullptr) {


### PR DESCRIPTION
Fixes #35
I also ran into the issue mentioned above: Whenever you use a Vector/Array valued macro in the Python code, e.g. VAL from a waveform, you will see a steady increase in memory footprint of the IOC. 

When the c++ vector is converted into a Python list, a Python object is created for each value, e.g. with PyFloat_FromDouble, and that Python object is appended to the list. The reference to the list is released, however the creation of the individual list elements also creates a reference for each one. Theese need to be released as well or Python will keep the objects until the whole application runs out of memory.

This fix is straightforward. Unfortunately, shoving even more code into the lengthy if-else chain reduces its readability further. Maybe it would be benificial to put the "item" creation into a separate, templated function? For clarity sake I wanted to keep the changes here minimal, but I could take a stab a clearing this part up, if there is interest.
