### PR TITLE
assign value to rval instead of val for mbbi record

### DIFF
--- a/src/pydev_mbbi.cpp
+++ b/src/pydev_mbbi.cpp
@@ -130,7 +130,7 @@ static void processRecordCb(mbbiRecord* rec)
             ctx->bytecode = PyWrapper::compile(code, (rec->tpro == 1));
             ctx->code = code;
         }
-        rec->val = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_long();
+        rec->rval = PyWrapper::eval(ctx->bytecode, args, (rec->tpro == 1)).get_long();
         rec->udf = 0;
         ctx->processCbStatus = 0;
 


### PR DESCRIPTION
See this issue for a description of the problem:

https://github.com/klemenv/PyDevice/issues/43

I believe the relevant code in base is here:

https://github.com/epics-base/epics-base/blob/7.0/modules/database/src/std/rec/mbbiRecord.c#L190

I think the val field gets overwritten by rval so setting val does not persist. If you write to .RVAL manually over channel access, the value persists, but not if you write to .VAL through channel access, which seems to support that rec->val is overwritten by rec->rval

In epics-base, in include/mbbiRecord.h there is the following struct:

```
typedef struct mbbidset {
    dset common; /* init_record returns: (-1,0) => (failure, success)*/
    long (*read_mbbi)(struct mbbiRecord *prec); /* (0, 2) => (success, success no convert)*/
} mbbidset;
```

read_mbbi seems to be implemented via this line:

https://github.com/klemenv/PyDevice/blob/main/src/pydev_mbbi.cpp#L178

read_mbbi gets called in readValue, which is called here:

https://github.com/epics-base/epics-base/blob/7.0/modules/database/src/std/rec/mbbiRecord.c#L159

But after readValue is called (which ultimately sets rec->val in processRecordCb), the record code sets rec->val back to rec->rval:

https://github.com/epics-base/epics-base/blob/7.0/modules/database/src/std/rec/mbbiRecord.c#L190

So setting rec->val in the device is fruitless, because the record code which the device implementation has no control over always just sets it back to rval.

So I think the simplest solution is simply to set rec->rval instead of rec->val

Edit: Making processRecord return 2 may also be another option