### PR TITLE
Fix duplicating each entry if a list of bools is returned

### DIFF
--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -302,11 +302,6 @@ bool PyWrapper::convert(void* in_, Variant& out)
                 vl.push_back(val);
                 t = Variant::Type::VECTOR_LONG;
             }
-            if (PyBool_Check(el) && (t == Variant::Type::NONE || t == Variant::Type::VECTOR_LONG)) {
-                long val = (PyObject_IsTrue(el) ? 1 : 0);
-                vl.push_back(val);
-                t = Variant::Type::VECTOR_LONG;
-            }
             if (PyFloat_Check(el) && (t == Variant::Type::NONE || t == Variant::Type::VECTOR_DOUBLE)) {
                 double val = PyFloat_AsDouble(el);
                 if (val == -1.0 && PyErr_Occurred()) {

--- a/src/pywrapper.cpp
+++ b/src/pywrapper.cpp
@@ -291,6 +291,7 @@ bool PyWrapper::convert(void* in_, Variant& out)
                 }
                 vl.push_back(val);
                 t = Variant::Type::VECTOR_LONG;
+                continue;
             }
 #endif
             if (PyLong_Check(el) && (t == Variant::Type::NONE || t == Variant::Type::VECTOR_LONG)) {
@@ -301,6 +302,7 @@ bool PyWrapper::convert(void* in_, Variant& out)
                 }
                 vl.push_back(val);
                 t = Variant::Type::VECTOR_LONG;
+                continue;
             }
             if (PyFloat_Check(el) && (t == Variant::Type::NONE || t == Variant::Type::VECTOR_DOUBLE)) {
                 double val = PyFloat_AsDouble(el);
@@ -310,10 +312,12 @@ bool PyWrapper::convert(void* in_, Variant& out)
                 }
                 vd.push_back(val);
                 t = Variant::Type::VECTOR_DOUBLE;
+                continue;
             }
 #if PY_MAJOR_VERSION < 3
             if (PyString_Check(el) && (t == Variant::Type::NONE || t == Variant::Type::VECTOR_STRING)) {
                 const char *cval = PyString_AsString(el);
+                continue;
 #else
             if (PyUnicode_Check(el) && (t == Variant::Type::NONE || t == Variant::Type::VECTOR_STRING)) {
                 const char *cval = PyBytes_AsString(PyUnicode_AsASCIIString(el));
@@ -324,6 +328,7 @@ bool PyWrapper::convert(void* in_, Variant& out)
                 }
                 vs.push_back(cval);
                 t = Variant::Type::VECTOR_STRING;
+                continue;
             }
         }
 


### PR DESCRIPTION
I noticed a bug, when returning a list of bools from python. Each entry would apear doubly in the EPICS waveform.

Take this database:
```
record(waveform, "bools") {
    field(DTYP, "pydev")
    field(FTVL, "CHAR")
    field(NELM, 10)
    field(PINI, "YES")
    field(INP, "@[True, False]*5")
}
```
The waveform should contain: 1,0,1,0,1,0,1,0,1,0. Instead it contains: 1,1,0,0,1,1,0,0,1,1

[Python bools are implemented as integers](https://docs.python.org/3.14/c-api/bool.html). 
Thus in pywrapper.cpp conversion the PyLong_Check matches and the PyBool_Check as well and each entry is pushed to val twice.
Since Bools are integers under the hood anyhow, I think there is no need for an extra case.